### PR TITLE
Updating go.uber.org/zap to v1.8.0

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -22,14 +22,15 @@ imports:
   - sl
 - name: go.uber.org/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
+- name: go.uber.org/multierr
+  version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/zap
-  version: a2773be06b9ac7c318a3a105b5c310af5730c6b4
+  version: eeedf312bc6c57391d84767a4cd413f02a917974
   subpackages:
   - buffer
   - internal/bufferpool
   - internal/color
   - internal/exit
-  - internal/multierror
   - zapcore
 - name: golang.org/x/text
   version: b19bf474d317b857955b12035d2c5acb57ce8b01

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/BurntSushi/toml
   version: v0.2.0
 - package: go.uber.org/zap
-  version: a2773be06b9ac7c318a3a105b5c310af5730c6b4
+  version: v1.8.0
 - package: github.com/softlayer/softlayer-go
   version: 7b4687c6b2502a895404bf40d555088ea500abc3
   subpackages:


### PR DESCRIPTION
current version is returning error
```
zap/stacktrace.go:28:2: use of internal package vendor/go.uber.org/zap/internal/bufferpool not allowed
```
with v.1.8.0 erro is gone