### PR TITLE
K8s ibm/ibmc-block integration

### DIFF
--- a/lib/provider/data_types.go
+++ b/lib/provider/data_types.go
@@ -66,6 +66,12 @@ type Volume struct {
 	// notes field as a map for all note fileds
 	// will keep   {"plugin":"ibm-file-plugin-56f7bd4db6-wx4pd","region":"us-south","cluster":"3a3fd80459014aca84f8a7e58e7a3ded","type":"Endurance","pvc":"one30","pv":"pvc-c7b4d6bd-63c5-11e8-811c-3a16fc403383","storgeclass":"ibmc-file-billing","reclaim":"Delete"}
 	VolumeNotes map[string]string
+
+	// LunID the lun of volume
+	LunID string `json:"lunId,omitempty"`
+
+	// TargetIPAddresses list of target IP addresses for iscsi
+	TargetIPAddresses []string `json:"IscsiTargetIpAddresses,omitempty"`
 }
 
 // Snapshot

--- a/volume-providers/softlayer/block/block_volume_manager.go
+++ b/volume-providers/softlayer/block/block_volume_manager.go
@@ -360,7 +360,7 @@ func (sls *SLBlockSession) VolumeGet(id string) (*provider.Volume, error) {
 	}
 
 	// Step 2: Get volume details from SL
-	mask := "id,username,capacityGb,createDate,snapshotCapacityGb,parentVolume[snapshotSizeBytes],storageType[keyName],serviceResource[datacenter[name]],provisionedIops,lunId,originalVolumeName,storageTierLevel,notes"
+	mask := mask := "id,username,capacityGb,createDate,snapshotCapacityGb,parentVolume[snapshotSizeBytes],storageType[keyName],serviceResource[datacenter[name]],provisionedIops,lunId,originalVolumeName,storageTierLevel,notes,iscsiTargetIpAddresses"
 	storageObj := sls.Backend.GetNetworkStorageIscsiService()
 	storage, err := storageObj.ID(volumeID).Mask(mask).GetObject()
 	if err != nil {

--- a/volume-providers/softlayer/utils/storage_utils.go
+++ b/volume-providers/softlayer/utils/storage_utils.go
@@ -459,6 +459,15 @@ func ConvertToVolumeType(storage datatypes.Network_Storage, logger *zap.Logger, 
 	if storage.CreateDate != nil {
 		volume.CreationTime, _ = time.Parse(time.RFC3339, storage.CreateDate.String())
 	}
+
+	if storage.LunId != nil {
+		volume.LunID = *storage.LunId
+	}
+
+	if len(storage.IscsiTargetIpAddresses) > 0 {
+		volume.TargetIPAddresses = storage.IscsiTargetIpAddresses
+	}
+
 	volume.VolumeNotes = newnotes
 	return
 }
@@ -472,7 +481,9 @@ func ConvertToNetworkStorage(storage datatypes.Network_Storage_Iscsi) datatypes.
 	networkStorageIscsi.SnapshotCapacityGb = storage.SnapshotCapacityGb
 	networkStorageIscsi.StorageTierLevel = storage.StorageTierLevel
 	networkStorageIscsi.CreateDate = storage.CreateDate
+	networkStorageIscsi.LunId = storage.LunId
 	networkStorageIscsi.ServiceResourceName = storage.ServiceResourceName
+	networkStorageIscsi.IscsiTargetIpAddresses = storage.IscsiTargetIpAddresses
 	return networkStorageIscsi
 }
 


### PR DESCRIPTION
ibm/ibmc-block has a requirements for PV creation

2 required fields which are specific for backend:
```
 "Lun": "<lun_ID>"
 "TargetPortal": "<IP_address>"
```
Adding these 2 fileds into Volume object

more info: https://console.bluemix.net/docs/containers/cs_storage_block.html#block_storage