### PR TITLE
Add credentials and auth IP to sl getvolume api

### DIFF
--- a/volume-providers/softlayer/block/block_volume_manager.go
+++ b/volume-providers/softlayer/block/block_volume_manager.go
@@ -355,7 +355,7 @@ func (sls *SLBlockSession) GetVolume(id string) (*provider.Volume, error) {
 	}
 
 	// Step 2: Get volume details from SL
-	mask := "id,username,serviceResourceBackendIpAddress,capacityGb,createDate,snapshotCapacityGb,parentVolume[snapshotSizeBytes],storageType[keyName],serviceResource[datacenter[name]],provisionedIops,lunId,originalVolumeName,storageTierLevel,notes,iscsiTargetIpAddresses"
+	mask := "id,username,serviceResourceBackendIpAddress,capacityGb,createDate,snapshotCapacityGb,parentVolume[snapshotSizeBytes],storageType[keyName],serviceResource[datacenter[name]],provisionedIops,lunId,originalVolumeName,storageTierLevel,notes,iscsiTargetIpAddresses,credentials,allowedIpAddresses.allowedHost.credential.username,allowedIpAddresses.allowedHost.credential.password,allowedIpAddresses.allowedHost.credential.id"
 	storageObj := sls.Backend.GetNetworkStorageIscsiService()
 	storage, err := storageObj.ID(volumeID).Mask(mask).GetObject()
 	if err != nil {

--- a/volume-providers/softlayer/utils/storage_utils.go
+++ b/volume-providers/softlayer/utils/storage_utils.go
@@ -480,6 +480,18 @@ func ConvertToVolumeType(storage datatypes.Network_Storage, logger *zap.Logger, 
 		volumeAttribs["fileNetworkMountAddress"] = *storage.FileNetworkMountAddress
 	}
 
+	if storage.AllowedIpAddresses != nil && len(storage.AllowedIpAddresses) > 0 {
+		volumeAttribs["username"] = *storage.AllowedIpAddresses[0].AllowedHost.Credential.Username
+		volumeAttribs["password"] = *storage.AllowedIpAddresses[0].AllowedHost.Credential.Password
+		volumeAttribs["initiatorName"] = *storage.AllowedIpAddresses[0].AllowedHost.Name
+		volumeAttribs["authIP"] = *storage.AllowedIpAddresses[0].IpAddress
+	} else if storage.Credentials != nil && len(storage.Credentials) > 0 {
+		volumeAttribs["username"] = *storage.Credentials[0].Username
+		volumeAttribs["password"] = *storage.Credentials[0].Password
+		volumeAttribs["initiatorName"] = *storage.AllowedIpAddresses[0].AllowedHost.Name
+		volumeAttribs["authIP"] = *storage.AllowedIpAddresses[0].IpAddress
+	}
+
 	volume.VolumeNotes = newnotes
 	volume.Attributes = volumeAttribs
 	return

--- a/volume-providers/softlayer/utils/storage_utils.go
+++ b/volume-providers/softlayer/utils/storage_utils.go
@@ -485,7 +485,7 @@ func ConvertToVolumeType(storage datatypes.Network_Storage, logger *zap.Logger, 
 		volumeAttribs["password"] = *storage.AllowedIpAddresses[0].AllowedHost.Credential.Password
 		volumeAttribs["initiatorName"] = *storage.AllowedIpAddresses[0].AllowedHost.Name
 		volumeAttribs["authIP"] = *storage.AllowedIpAddresses[0].IpAddress
-	} else if storage.Credentials != nil && len(storage.Credentials) > 0 {
+	} else if storage.Credentials != nil && len(storage.Credentials) > 0 && storage.AllowedIpAddresses != nil {
 		volumeAttribs["username"] = *storage.Credentials[0].Username
 		volumeAttribs["password"] = *storage.Credentials[0].Password
 		volumeAttribs["initiatorName"] = *storage.AllowedIpAddresses[0].AllowedHost.Name


### PR DESCRIPTION
In order to use authorization programmatically we need to return the credentials as part of getvolume request so we can login from our VMs.
Currently only IP based auth is functioning for both VM+bare metal for softlayer so we're going with this.