### PR TITLE
deauthorize SL volumes on delete to help caching effects in target

### DIFF
--- a/volume-providers/softlayer/common/session.go
+++ b/volume-providers/softlayer/common/session.go
@@ -123,8 +123,8 @@ func (sls *SLSession) DeleteVolume(vol *provider.Volume) error {
 	if vol.Attributes["authIP"] != "" {
 		volumeAuthorization := provider.VolumeAuthorization{
 			Volume:  *vol,
-			Subnets: "",
-			HostIPs: vol.Attributes["authIP"],
+			Subnets: nil,
+			HostIPs: []string{vol.Attributes["authIP"]},
 		}
 		err := sls.DeauthorizeVolume(volumeAuthorization)
 		if err != nil {

--- a/volume-providers/softlayer/common/session.go
+++ b/volume-providers/softlayer/common/session.go
@@ -119,7 +119,18 @@ func (sls *SLSession) DeleteVolume(vol *provider.Volume) error {
 	if volumeID == 0 {
 		return messages.GetUserError("E0035", nil)
 	}
-
+	//! Step 2- Deauthorize on delete
+	if vol.Attributes["authIP"] != "" {
+		volumeAuthorization := provider.VolumeAuthorization{
+			Volume:  *vol,
+			Subnets: "",
+			HostIPs: vol.Attributes["authIP"],
+		}
+		err := sls.DeauthorizeVolume(volumeAuthorization)
+		if err != nil {
+			return err
+		}
+	}
 	return sls.deleteStorage(volumeID)
 }
 


### PR DESCRIPTION
SL volumes which are not deauthorized but already deleted will continue to show up on the target portal (due to caching on the target) and could result in previously deleted devices interfering with a running cluster and/or the startup of a new cluster because of stale metadata resident on the deleted disk.
De-authorize this device from it's auth'd node to help manage this caching effect.
NOTE : 
This is dependent on f8bf5354cb2efa0db30fc9a8b7d9f6b901e67441 being merged to provide the authIP/credentials returned on getVolume.