### PR TITLE
Add softlayerOptions for volume attachment

### DIFF
--- a/lib/provider/volume_attachment.go
+++ b/lib/provider/volume_attachment.go
@@ -57,6 +57,8 @@ type VolumeAttachmentResponse struct {
 type VolumeAttachmentRequest struct {
 	VolumeID   string `json:"volumeID"`
 	InstanceID string `json:"instanceID"`
+	// Only for SL provider
+	SoftlayerOptions map[string]string `json:"softlayerOptions,omitempty"`
 	// Only for VPC provider
 	VPCVolumeAttachment *VolumeAttachment `json:"vpcVolumeAttachment"`
 	// Only IKS provider


### PR DESCRIPTION
SL Attachment needs access to additional volume fields like TargetIP, credentials, iqn, etc.
Use an optional Options field rather than issuing another getVolume request, or passing the volume object down.