### PR TITLE
Next-Gen Lib Changes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -159,12 +159,12 @@ type VPCProviderConfig struct {
 	APIVersion       string `toml:"api_version,omitempty" envconfig:"VPC_API_VERSION"`
 
 	//NG Properties
-	G2_EndpointURL      string `toml:"g2_riaas_endpoint_url"`
-	G2_TokenExchangeURL string `toml:"g2_token_exchange_endpoint_url"`
-	G2_APIKey           string `toml:"g2_api_key" json:"-"`
-	G2_ResourceGroupID  string `toml:"g2_resource_group_id"`
-	G2_VPCAPIGeneration int    `toml:"g2_vpc_api_generation" envconfig:"G2_VPC_API_GENERATION"`
-	G2_APIVersion       string `toml:"g2_api_version,omitempty" envconfig:"G2_VPC_API_VERSION"`
+	G2EndpointURL      string `toml:"g2_riaas_endpoint_url"`
+	G2TokenExchangeURL string `toml:"g2_token_exchange_endpoint_url"`
+	G2APIKey           string `toml:"g2_api_key" json:"-"`
+	G2ResourceGroupID  string `toml:"g2_resource_group_id"`
+	G2VPCAPIGeneration int    `toml:"g2_vpc_api_generation" envconfig:"G2_VPC_API_GENERATION"`
+	G2APIVersion       string `toml:"g2_api_version,omitempty" envconfig:"G2_VPC_API_VERSION"`
 
 	Encryption      bool   `toml:"encryption"`
 	VPCTimeout      string `toml:"vpc_api_timeout,omitempty" envconfig:"VPC_API_TIMEOUT"`

--- a/config/config.go
+++ b/config/config.go
@@ -144,20 +144,34 @@ type Gen2Config struct {
 
 // VPCProviderConfig configures a specific instance of a VPC provider (e.g. GT/GC/Z)
 type VPCProviderConfig struct {
-	Enabled              bool   `toml:"vpc_enabled" envconfig:"VPC_ENABLED"`
-	VPCBlockProviderName string `toml:"vpc_block_provider_name" envconfig:"VPC_BLOCK_PROVIDER_NAME"`
-	EndpointURL          string `toml:"gc_riaas_endpoint_url"`
-	TokenExchangeURL     string `toml:"gc_token_exchange_endpoint_url"`
-	APIKey               string `toml:"gc_api_key" json:"-"`
-	Encryption           bool   `toml:"encryption"`
-	ResourceGroupID      string `toml:"gc_resource_group_id"`
-	VPCTimeout           string `toml:"vpc_api_timeout,omitempty" envconfig:"VPC_API_TIMEOUT"`
-	MaxRetryAttempt      int    `toml:"max_retry_attempt,omitempty" envconfig:"VPC_RETRY_ATTEMPT"`
-	MaxRetryGap          int    `toml:"max_retry_gap,omitempty" envconfig:"VPC_RETRY_INTERVAL"`
-	VPCAPIGeneration     int    `toml:"vpc_api_generation" envconfig:"VPC_API_GENERATION"`
+	Enabled bool `toml:"vpc_enabled" envconfig:"VPC_ENABLED"`
 
-	APIVersion string `toml:"api_version,omitempty" envconfig:"VPC_API_VERSION"`
-	IsIKS      bool   `toml:"is_iks,omitempty"`
+	//valid values (gc|g2), if unspecified, GC will take precedence(if both are specified)
+	//during e2e test, user can specify its own preferred type during execution
+	VPCTypeEnabled       string `toml:"vpc_type_enabled" envconfig:"VPC_TYPE_ENABLED"`
+	VPCBlockProviderName string `toml:"vpc_block_provider_name" envconfig:"VPC_BLOCK_PROVIDER_NAME"`
+
+	EndpointURL      string `toml:"gc_riaas_endpoint_url"`
+	TokenExchangeURL string `toml:"gc_token_exchange_endpoint_url"`
+	APIKey           string `toml:"gc_api_key" json:"-"`
+	ResourceGroupID  string `toml:"gc_resource_group_id"`
+	VPCAPIGeneration int    `toml:"vpc_api_generation" envconfig:"VPC_API_GENERATION"`
+	APIVersion       string `toml:"api_version,omitempty" envconfig:"VPC_API_VERSION"`
+
+	//NG Properties
+	G2_EndpointURL      string `toml:"g2_riaas_endpoint_url"`
+	G2_TokenExchangeURL string `toml:"g2_token_exchange_endpoint_url"`
+	G2_APIKey           string `toml:"g2_api_key" json:"-"`
+	G2_ResourceGroupID  string `toml:"g2_resource_group_id"`
+	G2_VPCAPIGeneration int    `toml:"g2_vpc_api_generation" envconfig:"G2_VPC_API_GENERATION"`
+	G2_APIVersion       string `toml:"g2_api_version,omitempty" envconfig:"G2_VPC_API_VERSION"`
+
+	Encryption      bool   `toml:"encryption"`
+	VPCTimeout      string `toml:"vpc_api_timeout,omitempty" envconfig:"VPC_API_TIMEOUT"`
+	MaxRetryAttempt int    `toml:"max_retry_attempt,omitempty" envconfig:"VPC_RETRY_ATTEMPT"`
+	MaxRetryGap     int    `toml:"max_retry_gap,omitempty" envconfig:"VPC_RETRY_INTERVAL"`
+
+	IsIKS bool `toml:"is_iks,omitempty"`
 }
 
 //IKSConfig config

--- a/config/config.go
+++ b/config/config.go
@@ -150,6 +150,7 @@ type VPCProviderConfig struct {
 	//during e2e test, user can specify its own preferred type during execution
 	VPCTypeEnabled       string `toml:"vpc_type_enabled" envconfig:"VPC_TYPE_ENABLED"`
 	VPCBlockProviderName string `toml:"vpc_block_provider_name" envconfig:"VPC_BLOCK_PROVIDER_NAME"`
+	VPCBlockProviderType string `toml:"provider_type"`
 
 	EndpointURL      string `toml:"gc_riaas_endpoint_url"`
 	TokenExchangeURL string `toml:"gc_token_exchange_endpoint_url"`

--- a/e2e/config/vpc-config.toml
+++ b/e2e/config/vpc-config.toml
@@ -31,16 +31,27 @@
 
 [vpc]
   vpc_enabled = true
+  vpc_type_enabled = "gc"
   vpc_block_provider_name = "vpc-classic"
+
   gc_token_exchange_endpoint_url = "https://iam.bluemix.net"
   gc_riaas_endpoint_url = "https://RIAAS_ENDPOINT_URL:443"
   gc_resource_group_id = "RESOURCE_GROUP"
   gc_api_key = "IAM_API_KEY"
+  vpc_api_generation = 1
+  api_version = "2019-07-02"
+
+  g2_token_exchange_endpoint_url = "https://iam.bluemix.net"
+  g2_riaas_endpoint_url = "https://G2_RIAAS_ENDPOINT_URL:443"
+  g2_resource_group_id = "G2_RESOURCE_GROUP"
+  g2_api_key = "G2_IAM_API_KEY"
+  g2_vpc_api_generation = 2
+  g2_api_version = "2019-07-02"
+
   encryption = false
   vpc_timeout = "120s"
   max_retry_attempt  = 120
   max_retry_gap =  60
-  api_version = "2019-07-02"
 
 [IKS]
   iks_enabled = true

--- a/e2e/vpc/e2e_suite_test.go
+++ b/e2e/vpc/e2e_suite_test.go
@@ -53,8 +53,8 @@ var _ = BeforeSuite(func() {
 		Expect(err).To(HaveOccurred())
 	}
 
-	if conf.VPC != nil && conf.VPC.VPCTypeEnabled == "g2" && conf.VPC.G2_ResourceGroupID != "" {
-		resourceGroupID = conf.VPC.G2_ResourceGroupID
+	if conf.VPC != nil && conf.VPC.VPCTypeEnabled == "g2" && conf.VPC.G2ResourceGroupID != "" {
+		resourceGroupID = conf.VPC.G2ResourceGroupID
 	} else if conf.VPC != nil && conf.VPC.ResourceGroupID != "" {
 		resourceGroupID = conf.VPC.ResourceGroupID
 	}

--- a/e2e/vpc/e2e_suite_test.go
+++ b/e2e/vpc/e2e_suite_test.go
@@ -53,8 +53,9 @@ var _ = BeforeSuite(func() {
 		Expect(err).To(HaveOccurred())
 	}
 
-	// Check if debug log level enabled or not
-	if conf.VPC != nil && conf.VPC.ResourceGroupID != "" {
+	if conf.VPC != nil && conf.VPC.VPCTypeEnabled == "g2" && conf.VPC.G2_ResourceGroupID != "" {
+		resourceGroupID = conf.VPC.G2_ResourceGroupID
+	} else if conf.VPC != nil && conf.VPC.ResourceGroupID != "" {
 		resourceGroupID = conf.VPC.ResourceGroupID
 	}
 

--- a/e2e/vpc/vpc_create_six_volumes_attach_detach_delete_volumes.go
+++ b/e2e/vpc/vpc_create_six_volumes_attach_detach_delete_volumes.go
@@ -91,7 +91,6 @@ func CreateTestVolumes(numberOfVolumesRequired int) ([]*provider.Volume, error) 
 		volume = &provider.Volume{}
 
 		volume.VolumeType = volumeType
-		volume.VPCVolume.Generation = generation
 		volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 		volume.VPCVolume.Profile = &provider.Profile{Name: "5iops-tier"}
 		volume.Name = &volName

--- a/e2e/vpc/vpc_create_volume_10iops_tier.go
+++ b/e2e/vpc/vpc_create_volume_10iops_tier.go
@@ -35,7 +35,6 @@ var _ = Describe("ibmcloud-storage-volume-lib", func() {
 		volume = &provider.Volume{}
 
 		volume.VolumeType = volumeType
-		volume.VPCVolume.Generation = generation
 		volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 		volume.VPCVolume.Profile = &provider.Profile{Name: "10iops-tier"}
 		volume.Name = &volName

--- a/e2e/vpc/vpc_create_volume_5iops_tier.go
+++ b/e2e/vpc/vpc_create_volume_5iops_tier.go
@@ -35,7 +35,6 @@ var _ = Describe("ibmcloud-storage-volume-lib", func() {
 		volume = &provider.Volume{}
 
 		volume.VolumeType = volumeType
-		volume.VPCVolume.Generation = generation
 		volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 		volume.VPCVolume.Profile = &provider.Profile{Name: "5iops-tier"}
 		volume.Name = &volName

--- a/e2e/vpc/vpc_create_volume_attach_detach_volume.go
+++ b/e2e/vpc/vpc_create_volume_attach_detach_volume.go
@@ -101,11 +101,3 @@ var _ = Describe("ibmcloud-storage-volume-lib", func() {
 		fmt.Printf("\n\n")
 	})
 })
-
-func getenv(key, fallback string) string {
-	value := os.Getenv(key)
-	if len(value) == 0 {
-		return fallback
-	}
-	return value + "-"
-}

--- a/e2e/vpc/vpc_create_volume_attach_detach_volume.go
+++ b/e2e/vpc/vpc_create_volume_attach_detach_volume.go
@@ -36,7 +36,6 @@ var _ = Describe("ibmcloud-storage-volume-lib", func() {
 		volume = &provider.Volume{}
 
 		volume.VolumeType = volumeType
-		volume.VPCVolume.Generation = generation
 		volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 		volume.VPCVolume.Profile = &provider.Profile{Name: "5iops-tier"}
 		volume.Name = &volName

--- a/e2e/vpc/vpc_create_volume_custom_profile.go
+++ b/e2e/vpc/vpc_create_volume_custom_profile.go
@@ -35,7 +35,6 @@ var _ = Describe("ibmcloud-storage-volume-lib", func() {
 		volume = &provider.Volume{}
 
 		volume.VolumeType = volumeType
-		volume.VPCVolume.Generation = generation
 		volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 		volume.VPCVolume.Profile = &provider.Profile{Name: "custom"}
 		volume.Name = &volName

--- a/e2e/vpc/vpc_create_volume_with_encryption.go
+++ b/e2e/vpc/vpc_create_volume_with_encryption.go
@@ -15,12 +15,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"os"
+
 	"time"
 
 	"github.com/IBM/ibmcloud-storage-volume-lib/lib/provider"
-	userError "github.com/IBM/ibmcloud-storage-volume-lib/lib/utils"
 )
 
 var _ = Describe("ibmcloud-storage-volume-lib", func() {
@@ -81,35 +79,3 @@ var _ = Describe("ibmcloud-storage-volume-lib", func() {
 		fmt.Printf("\n\n")
 	})
 })
-
-func getContextLogger() (*zap.Logger, zap.AtomicLevel) {
-	consoleDebugging := zapcore.Lock(os.Stdout)
-	consoleErrors := zapcore.Lock(os.Stderr)
-	encoderConfig := zap.NewProductionEncoderConfig()
-	encoderConfig.TimeKey = "ts"
-	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
-	traceLevel := zap.NewAtomicLevel()
-	traceLevel.SetLevel(zap.InfoLevel)
-	core := zapcore.NewTee(
-		zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), consoleDebugging, zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-			return (lvl >= traceLevel.Level()) && (lvl < zapcore.ErrorLevel)
-		})),
-		zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), consoleErrors, zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-			return lvl >= zapcore.ErrorLevel
-		})),
-	)
-	logger := zap.New(core, zap.AddCaller())
-	return logger, traceLevel
-}
-
-func updateRequestID(err error, requestID string) error {
-	if err == nil {
-		return err
-	}
-	usrError, ok := err.(userError.Message)
-	if !ok {
-		return err
-	}
-	usrError.RequestID = requestID
-	return usrError
-}

--- a/e2e/vpc/vpc_create_volume_with_encryption.go
+++ b/e2e/vpc/vpc_create_volume_with_encryption.go
@@ -38,7 +38,6 @@ var _ = Describe("ibmcloud-storage-volume-lib", func() {
 		volume = &provider.Volume{}
 
 		volume.VolumeType = volumeType
-		volume.VPCVolume.Generation = generation
 		volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 		profile := vpcProfile
 		volume.VPCVolume.Profile = &provider.Profile{Name: profile}

--- a/e2e/vpc/vpc_create_volume_without_encryption.go
+++ b/e2e/vpc/vpc_create_volume_without_encryption.go
@@ -35,7 +35,6 @@ var _ = Describe("ibmcloud-storage-volume-lib", func() {
 		volume = &provider.Volume{}
 
 		volume.VolumeType = volumeType
-		volume.VPCVolume.Generation = generation
 		volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 		profile := vpcProfile
 		volume.VPCVolume.Profile = &provider.Profile{Name: profile}

--- a/e2e/vpc/vpc_create_volumes_with_different_sizes.go
+++ b/e2e/vpc/vpc_create_volumes_with_different_sizes.go
@@ -35,7 +35,6 @@ var _ = Describe("ibmcloud-storage-volume-lib", func() {
 		volume = &provider.Volume{}
 
 		volume.VolumeType = volumeType
-		volume.VPCVolume.Generation = generation
 		volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 		profile := vpcProfile
 		volume.VPCVolume.Profile = &provider.Profile{Name: profile}

--- a/lib/provider/vpc_data_types.go
+++ b/lib/provider/vpc_data_types.go
@@ -14,7 +14,6 @@ package provider
 type VPCVolume struct {
 	Href                string               `json:"href,omitempty"`
 	ResourceGroup       *ResourceGroup       `json:"resource_group,omitempty"`
-	Generation          GenerationType       `json:"generation,omitempty"`
 	VolumeEncryptionKey *VolumeEncryptionKey `json:"encryption_key,omitempty"`
 	Profile             *Profile             `json:"profile,omitempty"`
 	Tags                []string             `json:"volume_tags,omitempty"`

--- a/samples/main.go
+++ b/samples/main.go
@@ -352,7 +352,6 @@ func main() {
 			Iops := "0"
 
 			volume.Az = zone
-			volume.VPCVolume.Generation = "gt"
 
 			volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 

--- a/samples/vpc_create_volume_with_encryption.go
+++ b/samples/vpc_create_volume_with_encryption.go
@@ -107,7 +107,6 @@ func main() {
 	Iops := "0"
 
 	volume.Az = zone
-	volume.VPCVolume.Generation = "gt"
 
 	volume.VPCVolume.ResourceGroup = &provider.ResourceGroup{}
 

--- a/volume-providers/vpc/provider/attach_volume.go
+++ b/volume-providers/vpc/provider/attach_volume.go
@@ -62,7 +62,7 @@ func (vpcs *VPCSession) AttachVolume(volumeAttachmentRequest provider.VolumeAtta
 		userErr := userError.GetUserError(string(userError.VolumeAttachFailed), err, volumeAttachmentRequest.VolumeID, volumeAttachmentRequest.InstanceID)
 		return nil, userErr
 	}
-	varp := volumeAttachResult.ToVolumeAttachmentResponse()
+	varp := volumeAttachResult.ToVolumeAttachmentResponse(vpcs.Config.VPCBlockProviderType)
 	vpcs.Logger.Info("Successfully attached volume from VPC provider", zap.Reflect("volumeResponse", varp))
 	return varp, nil
 }

--- a/volume-providers/vpc/provider/create_volume.go
+++ b/volume-providers/vpc/provider/create_volume.go
@@ -41,7 +41,6 @@ func (vpcs *VPCSession) CreateVolume(volumeRequest provider.Volume) (volumeRespo
 		Iops:          iops,
 		Tags:          volumeRequest.VPCVolume.Tags,
 		ResourceGroup: &resourceGroup,
-		Generation:    models.GenerationType(volumeRequest.Generation),
 		Profile: &models.Profile{
 			Name: volumeRequest.VPCVolume.Profile.Name,
 		},

--- a/volume-providers/vpc/provider/get_volume_attachment.go
+++ b/volume-providers/vpc/provider/get_volume_attachment.go
@@ -67,7 +67,8 @@ func (vpcs *VPCSession) getVolumeAttachmentByID(volumeAttachmentRequest models.V
 		userErr := userError.GetUserError(string(userError.VolumeAttachFindFailed), err, volumeAttachmentRequest.Volume.ID, *volumeAttachmentRequest.InstanceID)
 		return nil, userErr
 	}
-	volumeAttachmentResponse := volumeAttachmentResult.ToVolumeAttachmentResponse()
+
+	volumeAttachmentResponse := volumeAttachmentResult.ToVolumeAttachmentResponse(vpcs.Config.VPCBlockProviderType)
 	vpcs.Logger.Info("Successfuly retrived volume attachment", zap.Reflect("volumeAttachmentResponse", volumeAttachmentResponse))
 	return volumeAttachmentResponse, err
 }
@@ -97,7 +98,7 @@ func (vpcs *VPCSession) getVolumeAttachmentByVolumeID(volumeAttachmentRequest mo
 		// Check if volume ID is matching with requested volume ID
 		if volumeAttachmentItem.Volume.ID == volumeAttachmentRequest.Volume.ID {
 			vpcs.Logger.Info("Successfully found volume attachment", zap.Reflect("volumeAttachment", volumeAttachmentItem))
-			volumeResponse := volumeAttachmentItem.ToVolumeAttachmentResponse()
+			volumeResponse := volumeAttachmentItem.ToVolumeAttachmentResponse(vpcs.Config.VPCBlockProviderType)
 			vpcs.Logger.Info("Successfully fetched volume attachment from VPC provider", zap.Reflect("volumeResponse", volumeResponse))
 			return volumeResponse, nil
 		}

--- a/volume-providers/vpc/provider/provider.go
+++ b/volume-providers/vpc/provider/provider.go
@@ -46,7 +46,7 @@ type VPCBlockProvider struct {
 	serverConfig   *config.ServerConfig
 	config         *config.VPCProviderConfig
 	tokenGenerator *tokenGenerator
-	contextCF      local.ContextCredentialsFactory
+	ContextCF      local.ContextCredentialsFactory
 
 	ClientProvider riaas.RegionalAPIClientProvider
 	httpClient     *http.Client
@@ -85,6 +85,18 @@ func NewProvider(conf *config.Config, logger *zap.Logger) (local.Provider, error
 		if conf.VPC.G2APIVersion != "" {
 			conf.VPC.APIVersion = conf.VPC.G2APIVersion
 		}
+
+		//set provider-type (this usually comes from the secret)
+		if conf.VPC.VPCBlockProviderType != "g2" {
+			conf.VPC.VPCBlockProviderType = "g2"
+		}
+
+		//Mark this as enabled/active
+		if conf.VPC.VPCTypeEnabled != "g2" {
+			conf.VPC.VPCTypeEnabled = "g2"
+		}
+	} else { //This is GC, no-override required
+		conf.VPC.VPCBlockProviderType = "gc" //incase of gc, i dont see its being set in slclient.toml, but NG cluster has this
 	}
 
 	// VPC provider use differnt APIkey and Auth Endpoint
@@ -121,7 +133,7 @@ func NewProvider(conf *config.Config, logger *zap.Logger) (local.Provider, error
 		serverConfig:   conf.Server,
 		config:         conf.VPC,
 		tokenGenerator: &tokenGenerator{config: conf.VPC},
-		contextCF:      contextCF,
+		ContextCF:      contextCF,
 		httpClient:     httpClient,
 		APIConfig: riaas.Config{
 			BaseURL:       conf.VPC.EndpointURL,
@@ -142,7 +154,7 @@ func NewProvider(conf *config.Config, logger *zap.Logger) (local.Provider, error
 // ContextCredentialsFactory ...
 func (vpcp *VPCBlockProvider) ContextCredentialsFactory(zone *string) (local.ContextCredentialsFactory, error) {
 	//  Datacenter hint not required by VPC provider implementation
-	return vpcp.contextCF, nil
+	return vpcp.ContextCF, nil
 }
 
 // OpenSession opens a session on the provider

--- a/volume-providers/vpc/provider/provider.go
+++ b/volume-providers/vpc/provider/provider.go
@@ -38,6 +38,10 @@ const (
 	vpcExceptionPrefix = "IBM Cloud infrastructure exception"
 	// timeoutDefault ...
 	timeoutDefault = "120s"
+	// VPCClassic ...
+	VPCClassic = "gc"
+	// VPCNextGen ...
+	VPCNextGen = "g2"
 )
 
 // VPCBlockProvider implements provider.Provider
@@ -68,7 +72,7 @@ func NewProvider(conf *config.Config, logger *zap.Logger) (local.Provider, error
 	g2ConfigFound := (conf.VPC.G2EndpointURL != "") && (conf.VPC.G2TokenExchangeURL != "") && (conf.VPC.G2APIKey != "") && (conf.VPC.G2ResourceGroupID != "")
 	//if both config found, look for VPCTypeEnabled, otherwise default to GC
 	//Incase of NG configurations, override the base properties.
-	if (gcConfigFound && g2ConfigFound && conf.VPC.VPCTypeEnabled == "g2") || (!gcConfigFound && g2ConfigFound) {
+	if (gcConfigFound && g2ConfigFound && conf.VPC.VPCTypeEnabled == VPCNextGen) || (!gcConfigFound && g2ConfigFound) {
 
 		conf.VPC.EndpointURL = conf.VPC.G2EndpointURL
 		conf.VPC.TokenExchangeURL = conf.VPC.G2TokenExchangeURL
@@ -87,16 +91,16 @@ func NewProvider(conf *config.Config, logger *zap.Logger) (local.Provider, error
 		}
 
 		//set provider-type (this usually comes from the secret)
-		if conf.VPC.VPCBlockProviderType != "g2" {
-			conf.VPC.VPCBlockProviderType = "g2"
+		if conf.VPC.VPCBlockProviderType != VPCNextGen {
+			conf.VPC.VPCBlockProviderType = VPCNextGen
 		}
 
 		//Mark this as enabled/active
-		if conf.VPC.VPCTypeEnabled != "g2" {
-			conf.VPC.VPCTypeEnabled = "g2"
+		if conf.VPC.VPCTypeEnabled != VPCNextGen {
+			conf.VPC.VPCTypeEnabled = VPCNextGen
 		}
 	} else { //This is GC, no-override required
-		conf.VPC.VPCBlockProviderType = "gc" //incase of gc, i dont see its being set in slclient.toml, but NG cluster has this
+		conf.VPC.VPCBlockProviderType = VPCClassic //incase of gc, i dont see its being set in slclient.toml, but NG cluster has this
 	}
 
 	// VPC provider use differnt APIkey and Auth Endpoint

--- a/volume-providers/vpc/provider/provider.go
+++ b/volume-providers/vpc/provider/provider.go
@@ -64,26 +64,26 @@ func NewProvider(conf *config.Config, logger *zap.Logger) (local.Provider, error
 	}
 
 	//Do config validation and enable only one generationType (i.e VPC-Classic | VPC-NG)
-	gc_config_found := (conf.VPC.EndpointURL != "") && (conf.VPC.TokenExchangeURL != "") && (conf.VPC.APIKey != "") && (conf.VPC.ResourceGroupID != "")
-	g2_config_found := (conf.VPC.G2_EndpointURL != "") && (conf.VPC.G2_TokenExchangeURL != "") && (conf.VPC.G2_APIKey != "") && (conf.VPC.G2_ResourceGroupID != "")
+	gcConfigFound := (conf.VPC.EndpointURL != "") && (conf.VPC.TokenExchangeURL != "") && (conf.VPC.APIKey != "") && (conf.VPC.ResourceGroupID != "")
+	g2ConfigFound := (conf.VPC.G2EndpointURL != "") && (conf.VPC.G2TokenExchangeURL != "") && (conf.VPC.G2APIKey != "") && (conf.VPC.G2ResourceGroupID != "")
 	//if both config found, look for VPCTypeEnabled, otherwise default to GC
 	//Incase of NG configurations, override the base properties.
-	if (gc_config_found && g2_config_found && conf.VPC.VPCTypeEnabled == "g2") || (!gc_config_found && g2_config_found) {
+	if (gcConfigFound && g2ConfigFound && conf.VPC.VPCTypeEnabled == "g2") || (!gcConfigFound && g2ConfigFound) {
 
-		conf.VPC.EndpointURL = conf.VPC.G2_EndpointURL
-		conf.VPC.TokenExchangeURL = conf.VPC.G2_TokenExchangeURL
-		conf.VPC.APIKey = conf.VPC.G2_APIKey
-		conf.VPC.ResourceGroupID = conf.VPC.G2_ResourceGroupID
+		conf.VPC.EndpointURL = conf.VPC.G2EndpointURL
+		conf.VPC.TokenExchangeURL = conf.VPC.G2TokenExchangeURL
+		conf.VPC.APIKey = conf.VPC.G2APIKey
+		conf.VPC.ResourceGroupID = conf.VPC.G2ResourceGroupID
 
 		//Set API Generation As 2 (if unspecified in config/ENV-VAR)
-		if conf.VPC.G2_VPCAPIGeneration <= 0 {
-			conf.VPC.G2_VPCAPIGeneration = 2
+		if conf.VPC.G2VPCAPIGeneration <= 0 {
+			conf.VPC.G2VPCAPIGeneration = 2
 		}
-		conf.VPC.VPCAPIGeneration = conf.VPC.G2_VPCAPIGeneration
+		conf.VPC.VPCAPIGeneration = conf.VPC.G2VPCAPIGeneration
 
 		//Set the APIVersion Date, it can be diffrent in GC and NG
-		if conf.VPC.G2_APIVersion != "" {
-			conf.VPC.APIVersion = conf.VPC.G2_APIVersion
+		if conf.VPC.G2APIVersion != "" {
+			conf.VPC.APIVersion = conf.VPC.G2APIVersion
 		}
 	}
 

--- a/volume-providers/vpc/provider/util.go
+++ b/volume-providers/vpc/provider/util.go
@@ -259,10 +259,10 @@ func FromProviderToLibVolume(vpcVolume *models.Volume, logger *zap.Logger) (libV
 	return
 }
 
-// IsValidVolumeIDFormat validating
+// IsValidVolumeIDFormat validating(gc has 5 parts and NG has 6 parts)
 func IsValidVolumeIDFormat(volID string) bool {
 	parts := strings.Split(volID, "-")
-	if len(parts) != volumeIDPartsCount {
+	if len(parts) < volumeIDPartsCount {
 		return false
 	}
 	return true

--- a/volume-providers/vpc/vpcclient/instances/attach_volume_test.go
+++ b/volume-providers/vpc/vpcclient/instances/attach_volume_test.go
@@ -74,8 +74,7 @@ func TestAttachVolume(t *testing.T) {
 					ResourceGroup: &models.ResourceGroup{
 						ID: "rg1",
 					},
-					Generation: models.GenerationType("gc"),
-					Zone:       &models.Zone{Name: "test-1"},
+					Zone: &models.Zone{Name: "test-1"},
 				},
 			}
 

--- a/volume-providers/vpc/vpcclient/instances/detach_volume_test.go
+++ b/volume-providers/vpc/vpcclient/instances/detach_volume_test.go
@@ -71,8 +71,7 @@ func TestDetachVolume(t *testing.T) {
 					ResourceGroup: &models.ResourceGroup{
 						ID: "rg1",
 					},
-					Generation: models.GenerationType("gc"),
-					Zone:       &models.Zone{Name: "test-1"},
+					Zone: &models.Zone{Name: "test-1"},
 				},
 			}
 

--- a/volume-providers/vpc/vpcclient/instances/get_volume_attachment_test.go
+++ b/volume-providers/vpc/vpcclient/instances/get_volume_attachment_test.go
@@ -64,7 +64,7 @@ func TestGetVolumeAttachment(t *testing.T) {
 					ResourceGroup: &models.ResourceGroup{
 						ID: "rg1",
 					},
-					Zone:       &models.Zone{Name: "test-1"},
+					Zone: &models.Zone{Name: "test-1"},
 				},
 			}
 

--- a/volume-providers/vpc/vpcclient/instances/get_volume_attachment_test.go
+++ b/volume-providers/vpc/vpcclient/instances/get_volume_attachment_test.go
@@ -64,7 +64,6 @@ func TestGetVolumeAttachment(t *testing.T) {
 					ResourceGroup: &models.ResourceGroup{
 						ID: "rg1",
 					},
-					Generation: models.GenerationType("gc"),
 					Zone:       &models.Zone{Name: "test-1"},
 				},
 			}

--- a/volume-providers/vpc/vpcclient/instances/iks_attach_volume_test.go
+++ b/volume-providers/vpc/vpcclient/instances/iks_attach_volume_test.go
@@ -46,7 +46,6 @@ func TestIKSAttachVolume(t *testing.T) {
 			ResourceGroup: &models.ResourceGroup{
 				ID: "rg1",
 			},
-			Generation: models.GenerationType("gc"),
 			Zone:       &models.Zone{Name: "test-1"},
 		},
 	}

--- a/volume-providers/vpc/vpcclient/instances/iks_attach_volume_test.go
+++ b/volume-providers/vpc/vpcclient/instances/iks_attach_volume_test.go
@@ -46,7 +46,7 @@ func TestIKSAttachVolume(t *testing.T) {
 			ResourceGroup: &models.ResourceGroup{
 				ID: "rg1",
 			},
-			Zone:       &models.Zone{Name: "test-1"},
+			Zone: &models.Zone{Name: "test-1"},
 		},
 	}
 	defer teardown()

--- a/volume-providers/vpc/vpcclient/instances/iks_detach_volume_test.go
+++ b/volume-providers/vpc/vpcclient/instances/iks_detach_volume_test.go
@@ -44,7 +44,6 @@ func TestIKSDetachVolume(t *testing.T) {
 			ResourceGroup: &models.ResourceGroup{
 				ID: "rg1",
 			},
-			Generation: models.GenerationType("gc"),
 			Zone:       &models.Zone{Name: "test-1"},
 		},
 	}

--- a/volume-providers/vpc/vpcclient/instances/iks_detach_volume_test.go
+++ b/volume-providers/vpc/vpcclient/instances/iks_detach_volume_test.go
@@ -44,7 +44,7 @@ func TestIKSDetachVolume(t *testing.T) {
 			ResourceGroup: &models.ResourceGroup{
 				ID: "rg1",
 			},
-			Zone:       &models.Zone{Name: "test-1"},
+			Zone: &models.Zone{Name: "test-1"},
 		},
 	}
 	defer teardown()

--- a/volume-providers/vpc/vpcclient/instances/iks_get_volume_attachment_test.go
+++ b/volume-providers/vpc/vpcclient/instances/iks_get_volume_attachment_test.go
@@ -45,7 +45,6 @@ func TestIKSGetVolumeAttachment(t *testing.T) {
 			ResourceGroup: &models.ResourceGroup{
 				ID: "rg1",
 			},
-			Generation: models.GenerationType("gc"),
 			Zone:       &models.Zone{Name: "test-1"},
 		},
 	}

--- a/volume-providers/vpc/vpcclient/instances/iks_get_volume_attachment_test.go
+++ b/volume-providers/vpc/vpcclient/instances/iks_get_volume_attachment_test.go
@@ -45,7 +45,7 @@ func TestIKSGetVolumeAttachment(t *testing.T) {
 			ResourceGroup: &models.ResourceGroup{
 				ID: "rg1",
 			},
-			Zone:       &models.Zone{Name: "test-1"},
+			Zone: &models.Zone{Name: "test-1"},
 		},
 	}
 	defer teardown()

--- a/volume-providers/vpc/vpcclient/instances/iks_list_volume_attachments_test.go
+++ b/volume-providers/vpc/vpcclient/instances/iks_list_volume_attachments_test.go
@@ -46,7 +46,6 @@ func TestIKSListVolumeAttachment(t *testing.T) {
 			ResourceGroup: &models.ResourceGroup{
 				ID: "rg1",
 			},
-			Generation: models.GenerationType("gc"),
 			Zone:       &models.Zone{Name: "test-1"},
 		},
 	}

--- a/volume-providers/vpc/vpcclient/instances/iks_list_volume_attachments_test.go
+++ b/volume-providers/vpc/vpcclient/instances/iks_list_volume_attachments_test.go
@@ -46,7 +46,7 @@ func TestIKSListVolumeAttachment(t *testing.T) {
 			ResourceGroup: &models.ResourceGroup{
 				ID: "rg1",
 			},
-			Zone:       &models.Zone{Name: "test-1"},
+			Zone: &models.Zone{Name: "test-1"},
 		},
 	}
 	defer teardown()

--- a/volume-providers/vpc/vpcclient/instances/list_volume_attachments_test.go
+++ b/volume-providers/vpc/vpcclient/instances/list_volume_attachments_test.go
@@ -74,8 +74,7 @@ func TestListVolumeAttachment(t *testing.T) {
 					ResourceGroup: &models.ResourceGroup{
 						ID: "rg1",
 					},
-					Generation: models.GenerationType("gc"),
-					Zone:       &models.Zone{Name: "test-1"},
+					Zone: &models.Zone{Name: "test-1"},
 				},
 			}
 

--- a/volume-providers/vpc/vpcclient/models/constants.go
+++ b/volume-providers/vpc/vpcclient/models/constants.go
@@ -31,4 +31,7 @@ const (
 
 	// GTypeG2DevicePrefix ...
 	GTypeG2DevicePrefix = "/dev/disk/by-id/virtio-"
+
+	// VolumeAttached ...
+	VolumeAttached = "attached"
 )

--- a/volume-providers/vpc/vpcclient/models/constants.go
+++ b/volume-providers/vpc/vpcclient/models/constants.go
@@ -32,6 +32,9 @@ const (
 	// GTypeG2DevicePrefix ...
 	GTypeG2DevicePrefix = "/dev/disk/by-id/virtio-"
 
+	// GTypeG2DeviceIDLength ...
+	GTypeG2DeviceIDLength = 20
+
 	// VolumeAttached ...
 	VolumeAttached = "attached"
 )

--- a/volume-providers/vpc/vpcclient/models/constants.go
+++ b/volume-providers/vpc/vpcclient/models/constants.go
@@ -25,4 +25,10 @@ const (
 
 	// GTypeClassicDevicePrefix ...
 	GTypeClassicDevicePrefix = "/dev/"
+
+	// GTypeG2 ...
+	GTypeG2 = "g2"
+
+	// GTypeG2DevicePrefix ...
+	GTypeG2DevicePrefix = "/dev/disk/by-id/virtio-"
 )

--- a/volume-providers/vpc/vpcclient/models/volume.go
+++ b/volume-providers/vpc/vpcclient/models/volume.go
@@ -22,7 +22,6 @@ type Volume struct {
 	VolumeEncryptionKey *VolumeEncryptionKey `json:"encryption_key,omitempty"`
 	ResourceGroup       *ResourceGroup       `json:"resource_group,omitempty"`
 	Tags                []string             `json:"tags,omitempty"`
-	Generation          GenerationType       `json:"generation,omitempty"`
 	Profile             *Profile             `json:"profile,omitempty"`
 	Snapshot            *Snapshot            `json:"snapshot,omitempty"`
 	CreatedAt           *time.Time           `json:"created_at,omitempty"`

--- a/volume-providers/vpc/vpcclient/models/volume_attachment.go
+++ b/volume-providers/vpc/vpcclient/models/volume_attachment.go
@@ -86,16 +86,13 @@ func (va *VolumeAttachment) ToVolumeAttachmentResponse(providerType string) *pro
 	}
 
 	//Set DevicePath
-	if va.Status == "attached" {
+	if va.Status == VolumeAttached && va.Device != nil && va.Device.ID != "" {
 		if providerType == GTypeG2 {
-			if va.ID != "" && len(va.ID) >= 20 {
-				devicepath := GTypeG2DevicePrefix + va.ID[:20] // TODO: This might change after riaas side fixes
-				varp.VolumeAttachmentRequest.VPCVolumeAttachment.DevicePath = devicepath
+			if len(va.Device.ID) >= 20 {
+				varp.VolumeAttachmentRequest.VPCVolumeAttachment.DevicePath = GTypeG2DevicePrefix + va.Device.ID[:20]
 			}
-		} else // GC
-		if va.Device != nil && va.Device.ID != "" {
-			devicepath := GTypeClassicDevicePrefix + va.Device.ID
-			varp.VolumeAttachmentRequest.VPCVolumeAttachment.DevicePath = devicepath
+		} else { //GC
+			varp.VolumeAttachmentRequest.VPCVolumeAttachment.DevicePath = GTypeClassicDevicePrefix + va.Device.ID
 		}
 	}
 	return varp

--- a/volume-providers/vpc/vpcclient/models/volume_attachment.go
+++ b/volume-providers/vpc/vpcclient/models/volume_attachment.go
@@ -98,6 +98,13 @@ func (va *VolumeAttachment) ToVolumeAttachmentResponse() *provider.VolumeAttachm
 			devicepath = GTypeClassicDevicePrefix + va.Device.ID
 		}
 		varp.VolumeAttachmentRequest.VPCVolumeAttachment.DevicePath = devicepath
+
+		// TODO: This needs change, after device id for NG gets implemented
+	} else if va.Volume != nil && va.Volume.Generation == GTypeG2 {
+		if va.ID != "" && len(va.ID) >= 20 {
+			devicepath := GTypeG2DevicePrefix + va.ID[:20]
+			varp.VolumeAttachmentRequest.VPCVolumeAttachment.DevicePath = devicepath
+		}
 	}
 	return varp
 }

--- a/volume-providers/vpc/vpcclient/models/volume_attachment.go
+++ b/volume-providers/vpc/vpcclient/models/volume_attachment.go
@@ -88,8 +88,8 @@ func (va *VolumeAttachment) ToVolumeAttachmentResponse(providerType string) *pro
 	//Set DevicePath
 	if va.Status == VolumeAttached && va.Device != nil && va.Device.ID != "" {
 		if providerType == GTypeG2 {
-			if len(va.Device.ID) >= 20 {
-				varp.VolumeAttachmentRequest.VPCVolumeAttachment.DevicePath = GTypeG2DevicePrefix + va.Device.ID[:20]
+			if len(va.Device.ID) >= GTypeG2DeviceIDLength {
+				varp.VolumeAttachmentRequest.VPCVolumeAttachment.DevicePath = GTypeG2DevicePrefix + va.Device.ID[:GTypeG2DeviceIDLength]
 			}
 		} else { //GC
 			varp.VolumeAttachmentRequest.VPCVolumeAttachment.DevicePath = GTypeClassicDevicePrefix + va.Device.ID

--- a/volume-providers/vpc/vpcclient/models/volume_attachment.go
+++ b/volume-providers/vpc/vpcclient/models/volume_attachment.go
@@ -23,14 +23,14 @@ type Device struct {
 
 // VolumeAttachment for riaas client
 type VolumeAttachment struct {
-	ID   string `json:"id"`
+	ID   string `json:"id,omitempty"`
 	Href string `json:"href,omitempty"`
 	Name string `json:"name,omitempty"`
 	// Status of volume attachment named - attaching , attached, detaching
 	Status string `json:"status,omitempty"`
 	Type   string `json:"type,omitempty"` //boot, data
 	// InstanceID this volume is attached to
-	InstanceID *string    `json:"instance_id,omitempty"`
+	InstanceID *string    `json:"-"`
 	ClusterID  *string    `json:"clusterID,omitempty"`
 	Device     *Device    `json:"device,omitempty"`
 	Volume     *Volume    `json:"volume,omitempty"`

--- a/volume-providers/vpc/vpcclient/vpcvolume/create_volume_test.go
+++ b/volume-providers/vpc/vpcclient/vpcvolume/create_volume_test.go
@@ -83,8 +83,7 @@ func TestCreateVolume(t *testing.T) {
 				ResourceGroup: &models.ResourceGroup{
 					ID: "rg1",
 				},
-				Generation: models.GenerationType("gen1"),
-				Zone:       &models.Zone{Name: "test-1"},
+				Zone: &models.Zone{Name: "test-1"},
 			}
 
 			mux, client, teardown := test.SetupServer(t)


### PR DESCRIPTION
**Fixes:**

1. Added configs for NG including the Generation and Version
2. Provider uses the configurations for first looking for GC and then NG (if both found)
3. An additional Optional param "VPCTypeEnabled" has been added, which will be used in case both GC and NG config available and User wants to use a particular one (i.e e2e will use this)
4. Few Testcase like "encryption" , which not valid for NG needs to be filtered out during ng-e2e
5. expected devicepath for NG has been added to attachment

**Tests:**
1. Deviceid fixes has been tested ok.
2. volume-lib e2e has been tested ok and jenkin has been enabled
3. Driver e2e has been tested OK
https://github.ibm.com/alchemy-containers/ibm-vpc-block-csi-driver/pull/190