### PR TITLE
PSIRT PVR0322596

### DIFF
--- a/e2e-final/vpc/e2e_suite_test.go
+++ b/e2e-final/vpc/e2e_suite_test.go
@@ -29,7 +29,7 @@ import (
 	provider_util "github.com/IBM/ibmcloud-volume-vpc/block/utils"
 	vpcconfig "github.com/IBM/ibmcloud-volume-vpc/block/vpcconfig"
 	"github.com/IBM/ibmcloud-volume-vpc/common/registry"
-	uid "github.com/satori/go.uuid"
+	gouid "github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -139,8 +139,8 @@ func loadConfig() {
 	}
 
 	ctxLogger, _ = getContextLogger()
-	requestID = uid.NewV4().String()
-	ctxLogger = logger.With(zap.String("RequestID", requestID))
+	requestID, _ = gouid.NewV4()
+	ctxLogger = logger.With(zap.String("RequestID", requestID.Bytes()))
 
 	initializeProvider()
 }
@@ -182,8 +182,8 @@ func initVPCBlockProvider() {
 	}
 
 	ctxLogger, _ = getContextLogger()
-	requestID = uid.NewV4().String()
-	ctxLogger = logger.With(zap.String("RequestID", requestID))
+	requestID, _ = gouid.NewV4()
+	ctxLogger = logger.With(zap.String("RequestID", requestID.Bytes()))
 
 	// Prepare provider registry
 	providerRegistry, err = provider_util.InitProviders(vpcBlockConfig, ctxLogger)

--- a/e2e-final/vpc/e2e_suite_test.go
+++ b/e2e-final/vpc/e2e_suite_test.go
@@ -140,8 +140,8 @@ func loadConfig() {
 
 	ctxLogger, _ = getContextLogger()
 	gouuidObj, _ := gouid.NewV4()
-	requestID = string(gouuidObj.Bytes())
-	ctxLogger = logger.With(zap.String("RequestID", string(requestID)))
+	requestID =  gouuidObj.String()
+	ctxLogger = logger.With(zap.String("RequestID", requestID))
 
 	initializeProvider()
 }
@@ -184,8 +184,8 @@ func initVPCBlockProvider() {
 
 	ctxLogger, _ = getContextLogger()
 	gouuidObj, _ := gouid.NewV4()
-	requestID = string(gouuidObj.Bytes())
-	ctxLogger = logger.With(zap.String("RequestID", string(requestID)))
+	requestID = gouuidObj.String()
+	ctxLogger = logger.With(zap.String("RequestID", requestID))
 
 	// Prepare provider registry
 	providerRegistry, err = provider_util.InitProviders(vpcBlockConfig, ctxLogger)

--- a/e2e-final/vpc/e2e_suite_test.go
+++ b/e2e-final/vpc/e2e_suite_test.go
@@ -45,13 +45,13 @@ var providerRegistry registry.Providers
 var logger *zap.Logger
 var ctxLogger *zap.Logger
 var traceLevel zap.AtomicLevel
-var requestID string
 var resourceGroupID string
 var volumeEncryptionKeyCRN string
 var startTime time.Time
 var providerName string
 var conf *config.Config
 var err error
+var requestID string
 
 var testCaseList []TestCaseData
 var goPath string
@@ -139,8 +139,9 @@ func loadConfig() {
 	}
 
 	ctxLogger, _ = getContextLogger()
-	requestID, _ = gouid.NewV4()
-	ctxLogger = logger.With(zap.String("RequestID", requestID.Bytes()))
+	gouuidObj, _ := gouid.NewV4()
+	requestID = string(gouuidObj.Bytes())
+	ctxLogger = logger.With(zap.String("RequestID", string(requestID)))
 
 	initializeProvider()
 }
@@ -182,8 +183,9 @@ func initVPCBlockProvider() {
 	}
 
 	ctxLogger, _ = getContextLogger()
-	requestID, _ = gouid.NewV4()
-	ctxLogger = logger.With(zap.String("RequestID", requestID.Bytes()))
+	gouuidObj, _ := gouid.NewV4()
+	requestID = string(gouuidObj.Bytes())
+	ctxLogger = logger.With(zap.String("RequestID", string(requestID)))
 
 	// Prepare provider registry
 	providerRegistry, err = provider_util.InitProviders(vpcBlockConfig, ctxLogger)

--- a/e2e/vpc/e2e_suite_test.go
+++ b/e2e/vpc/e2e_suite_test.go
@@ -39,12 +39,12 @@ var providerRegistryBlock registry.Providers
 var logger *zap.Logger
 var ctxLogger *zap.Logger
 var traceLevel zap.AtomicLevel
-var requestID string
 var resourceGroupID string
 var vpcZone string
 var volumeEncryptionKeyCRN string
 var startTime time.Time
 var providerName string
+var requestID string
 
 func TestVPCE2e(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -96,8 +96,9 @@ var _ = BeforeSuite(func() {
 	}
 
 	ctxLogger, _ = getContextLogger()
-	requestID, _ = gouid.NewV4()
-	ctxLogger = logger.With(zap.String("RequestID", requestID))
+	gouuidObj, _ := gouid.NewV4()
+	requestID = string(gouuidObj.Bytes())
+	ctxLogger = logger.With(zap.String("RequestID", string(requestID)))
 
 	// Prepare provider registry
 	providerRegistryBlock, err = provider_util.InitProviders(vpcBlockConfig, ctxLogger)

--- a/e2e/vpc/e2e_suite_test.go
+++ b/e2e/vpc/e2e_suite_test.go
@@ -28,7 +28,7 @@ import (
 	provider_util "github.com/IBM/ibmcloud-volume-vpc/block/utils"
 	vpcconfig "github.com/IBM/ibmcloud-volume-vpc/block/vpcconfig"
 	"github.com/IBM/ibmcloud-volume-vpc/common/registry"
-	uid "github.com/satori/go.uuid"
+	gouid "github.com/gofrs/uuid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -96,7 +96,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	ctxLogger, _ = getContextLogger()
-	requestID = uid.NewV4().String()
+	requestID, _ = gouid.NewV4()
 	ctxLogger = logger.With(zap.String("RequestID", requestID))
 
 	// Prepare provider registry

--- a/e2e/vpc/e2e_suite_test.go
+++ b/e2e/vpc/e2e_suite_test.go
@@ -97,8 +97,8 @@ var _ = BeforeSuite(func() {
 
 	ctxLogger, _ = getContextLogger()
 	gouuidObj, _ := gouid.NewV4()
-	requestID = string(gouuidObj.Bytes())
-	ctxLogger = logger.With(zap.String("RequestID", string(requestID)))
+	requestID = gouuidObj.String()
+	ctxLogger = logger.With(zap.String("RequestID", requestID))
 
 	// Prepare provider registry
 	providerRegistryBlock, err = provider_util.InitProviders(vpcBlockConfig, ctxLogger)

--- a/go.mod
+++ b/go.mod
@@ -25,5 +25,4 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 )
 
-replace github.com/satori/go.uuid => github.com/gofrs/uuid/v4 v4.2.0 
 replace k8s.io/apiserver => k8s.io/apiserver v0.0.0-20190313205120-8b27c41bdbb1

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/IBM/ibmcloud-volume-vpc v1.0.0-beta12
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fatih/structs v1.1.0
+	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/jarcoal/httpmock v1.0.8 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo v1.10.3
@@ -17,7 +18,6 @@ require (
 	github.com/pierrre/gotestcover v0.0.0-20160517101806-924dca7d15f0 // indirect
 	github.com/prometheus/client_golang v1.8.0
 	github.com/renier/xmlrpc v0.0.0-20170708154548-ce4a1a486c03 // indirect
-	github.com/satori/go.uuid v1.2.0
 	github.com/softlayer/softlayer-go v0.0.0-20181027013155-82a74c5bf7ff
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.15.0
@@ -25,4 +25,5 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 )
 
+replace github.com/satori/go.uuid => github.com/gofrs/uuid/v4 v4.2.0 
 replace k8s.io/apiserver => k8s.io/apiserver v0.0.0-20190313205120-8b27c41bdbb1

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nA
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
+github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -334,7 +336,6 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/samples/main.go
+++ b/samples/main.go
@@ -25,7 +25,7 @@ import (
 	userError "github.com/IBM/ibmcloud-storage-volume-lib/lib/utils"
 	"github.com/IBM/ibmcloud-storage-volume-lib/provider/local"
 	provider_util "github.com/IBM/ibmcloud-storage-volume-lib/provider/utils"
-	uid "github.com/satori/go.uuid"
+	uid "github.com/gofrs/uuid"
 )
 
 var (
@@ -120,16 +120,16 @@ func main() {
 			continue
 		}
 		ctxLogger, _ := getContextLogger1()
-		requestID := uid.NewV4().String()
-		ctxLogger = ctxLogger.With(zap.String("RequestID", requestID))
-		ctx := context.WithValue(nil, provider.RequestID, requestID)
+		requestID, _ := uid.NewV4()
+		ctxLogger = ctxLogger.With(zap.String("RequestID", string(requestID.Bytes())))
+		ctx := context.WithValue(nil, provider.RequestID, requestID.Bytes())
 		sess, _, err := provider_util.OpenProviderSessionWithContext(ctx, conf, providerRegistry, providerName, ctxLogger)
 		if err != nil {
 			ctxLogger.Error("Failed to get session", zap.Reflect("Error", err))
 			continue
 		}
-		volumeAttachmentManager := NewVolumeAttachmentManager(sess, ctxLogger, requestID)
-		volumeManager := NewVolumeManager(sess, ctxLogger, requestID)
+		volumeAttachmentManager := NewVolumeAttachmentManager(sess, ctxLogger, string(requestID.Bytes()))
+		volumeManager := NewVolumeManager(sess, ctxLogger, string(requestID.Bytes()))
 
 		defer sess.Close()
 		defer ctxLogger.Sync()
@@ -142,7 +142,7 @@ func main() {
 				ctxLogger.Info("SUCCESSFULLY get volume details ================>", zap.Reflect("VolumeDetails", volume))
 			} else {
 				ctxLogger.Info("Provider error is ================>", zap.Reflect("ErrorType", userError.GetErrorType(errr)))
-				errr = updateRequestID(errr, requestID)
+				errr = updateRequestID(errr, string(requestID.Bytes()))
 				ctxLogger.Info("FAILED to get volume details ================>", zap.Reflect("VolumeID", volumeID), zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -160,7 +160,7 @@ func main() {
 				ctxLogger.Info("Successfully created snapshot on ================>", zap.Reflect("VolumeID", volumeID))
 				ctxLogger.Info("Snapshot details: ", zap.Reflect("Snapshot", snapshot))
 			} else {
-				errr = updateRequestID(errr, requestID)
+				errr = updateRequestID(errr, string(requestID.Bytes()))
 				ctxLogger.Info("Failed to create snapshot on ================>", zap.Reflect("VolumeID", volumeID), zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -174,7 +174,7 @@ func main() {
 				ctxLogger.Info("Successfully get snapshot details ================>", zap.Reflect("Snapshot ID", volumeID))
 				ctxLogger.Info("List of snapshots ", zap.Reflect("Snapshots are->", snapshots))
 			} else {
-				errr = updateRequestID(errr, requestID)
+				errr = updateRequestID(errr, string(requestID.Bytes()))
 				ctxLogger.Info("Failed to get snapshot details ================>", zap.Reflect("Snapshot ID", volumeID), zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -226,7 +226,7 @@ func main() {
 			if errr == nil {
 				ctxLogger.Info("Successfully ordered volume ================>", zap.Reflect("volumeObj", volumeObj))
 			} else {
-				errr = updateRequestID(errr, requestID)
+				errr = updateRequestID(errr, string(requestID.Bytes()))
 				ctxLogger.Info("Failed to order volume ================>", zap.Reflect("StorageType", volume.ProviderType), zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -257,7 +257,7 @@ func main() {
 			if er11 == nil {
 				ctxLogger.Info("Successfully ordered snapshot space ================>", zap.Reflect("Volume ID", volumeID))
 			} else {
-				er11 = updateRequestID(er11, requestID)
+				er11 = updateRequestID(er11, string(requestID.Bytes()))
 				ctxLogger.Info("failed to order snapshot space================>", zap.Reflect("Volume ID", volumeID), zap.Reflect("Error", er11))
 			}
 			fmt.Printf("\n\n")
@@ -276,7 +276,7 @@ func main() {
 				ctxLogger.Info("Successfully Created volume from snapshot ================>", zap.Reflect("OriginalVolumeID", volumeID), zap.Reflect("SnapshotID", snapshotID))
 				ctxLogger.Info("New volume from snapshot================>", zap.Reflect("New Volume->", vol))
 			} else {
-				errr = updateRequestID(errr, requestID)
+				errr = updateRequestID(errr, string(requestID.Bytes()))
 				ctxLogger.Info("Failed to create volume from snapshot ================>", zap.Reflect("OriginalVolumeID", volumeID), zap.Reflect("SnapshotID", snapshotID), zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -290,7 +290,7 @@ func main() {
 			if er11 == nil {
 				ctxLogger.Info("SUCCESSFULLY deleted volume ================>", zap.Reflect("Volume ID", volumeID))
 			} else {
-				er11 = updateRequestID(er11, requestID)
+				er11 = updateRequestID(er11, string(requestID.Bytes()))
 				ctxLogger.Info("FAILED volume deletion================>", zap.Reflect("Volume ID", volumeID), zap.Reflect("Error", er11))
 			}
 			fmt.Printf("\n\n")
@@ -304,7 +304,7 @@ func main() {
 			if er11 == nil {
 				ctxLogger.Info("Successfully deleted snapshot ================>", zap.Reflect("Snapshot ID", snapshotID))
 			} else {
-				er11 = updateRequestID(er11, requestID)
+				er11 = updateRequestID(er11, string(requestID.Bytes()))
 				ctxLogger.Info("failed snapshot deletion================>", zap.Reflect("Snapshot ID", snapshotID), zap.Reflect("Error", er11))
 			}
 			fmt.Printf("\n\n")
@@ -314,7 +314,7 @@ func main() {
 			if errr == nil {
 				ctxLogger.Info("SUCCESSFULLY got all snapshots ================>", zap.Reflect("Snapshots", list))
 			} else {
-				errr = updateRequestID(errr, requestID)
+				errr = updateRequestID(errr, string(requestID.Bytes()))
 				ctxLogger.Info("FAILED All snapshots ================>", zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -324,7 +324,7 @@ func main() {
 			_, er11 = fmt.Scanf("%s", &volumeID)
 			_, error1 := sess.ListAllSnapshots(volumeID)
 			if error1 != nil {
-				error1 = updateRequestID(error1, requestID)
+				error1 = updateRequestID(error1, string(requestID.Bytes()))
 				ctxLogger.Info("Failed to get volumeID", zap.Reflect("Error", error1))
 			}
 		} else if choiceN == 12 {
@@ -351,7 +351,7 @@ func main() {
 			}
 			error1 := sess.AuthorizeVolume(authRequest)
 			if error1 != nil {
-				error1 = updateRequestID(error1, requestID)
+				error1 = updateRequestID(error1, string(requestID.Bytes()))
 				ctxLogger.Info("Failed to authorize", zap.Reflect("Error", error1))
 			}
 		} else if choiceN == 13 {
@@ -412,7 +412,7 @@ func main() {
 			if errr == nil {
 				ctxLogger.Info("SUCCESSFULLY created volume...", zap.Reflect("volumeObj", volumeObj))
 			} else {
-				errr = updateRequestID(errr, requestID)
+				errr = updateRequestID(errr, string(requestID.Bytes()))
 				ctxLogger.Info("FAILED to create volume...", zap.Reflect("StorageType", volume.ProviderType), zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -427,7 +427,7 @@ func main() {
 			if er11 == nil {
 				ctxLogger.Info("Successfully ordered snapshot space ================>", zap.Reflect("Volume ID", volumeID))
 			} else {
-				er11 = updateRequestID(er11, requestID)
+				er11 = updateRequestID(er11, string(requestID.Bytes()))
 				ctxLogger.Info("failed to order snapshot space================>", zap.Reflect("Volume ID", volumeID), zap.Reflect("Error", er11))
 			}
 			fmt.Printf("\n\n")
@@ -444,7 +444,7 @@ func main() {
 			if er11 == nil {
 				ctxLogger.Info("Successfully got VPC volume details ================>", zap.Reflect("VolumeDetail", volumeobj1))
 			} else {
-				er11 = updateRequestID(er11, requestID)
+				er11 = updateRequestID(er11, string(requestID.Bytes()))
 				ctxLogger.Info("failed to order snapshot space================>", zap.Reflect("VolumeName", volumeName), zap.Reflect("Error", er11))
 			}
 			fmt.Printf("\n\n")
@@ -485,7 +485,7 @@ func main() {
 						continue
 					}
 				} else {
-					er11 = updateRequestID(er11, requestID)
+					er11 = updateRequestID(er11, string(requestID.Bytes()))
 					ctxLogger.Info("failed to list volumes================>", zap.Reflect("Error", er11))
 				}
 				break
@@ -505,7 +505,7 @@ func main() {
 			if er11 == nil {
 				ctxLogger.Info("Successfully expanded volume ================>", zap.Reflect("Volume ID", expandedVolumeSize))
 			} else {
-				er11 = updateRequestID(er11, requestID)
+				er11 = updateRequestID(er11, string(requestID.Bytes()))
 				ctxLogger.Info("failed to expand================>", zap.Reflect("Volume ID", volumeID), zap.Reflect("Error", er11))
 			}
 			fmt.Printf("\n\n")

--- a/samples/main.go
+++ b/samples/main.go
@@ -121,15 +121,15 @@ func main() {
 		}
 		ctxLogger, _ := getContextLogger1()
 		requestID, _ := uid.NewV4()
-		ctxLogger = ctxLogger.With(zap.String("RequestID", string(requestID.Bytes())))
-		ctx := context.WithValue(nil, provider.RequestID, requestID.Bytes())
+		ctxLogger = ctxLogger.With(zap.String("RequestID", requestID.String()))
+		ctx := context.WithValue(nil, provider.RequestID, requestID.String())
 		sess, _, err := provider_util.OpenProviderSessionWithContext(ctx, conf, providerRegistry, providerName, ctxLogger)
 		if err != nil {
 			ctxLogger.Error("Failed to get session", zap.Reflect("Error", err))
 			continue
 		}
-		volumeAttachmentManager := NewVolumeAttachmentManager(sess, ctxLogger, string(requestID.Bytes()))
-		volumeManager := NewVolumeManager(sess, ctxLogger, string(requestID.Bytes()))
+		volumeAttachmentManager := NewVolumeAttachmentManager(sess, ctxLogger, requestID.String())
+		volumeManager := NewVolumeManager(sess, ctxLogger, requestID.String())
 
 		defer sess.Close()
 		defer ctxLogger.Sync()
@@ -142,7 +142,7 @@ func main() {
 				ctxLogger.Info("SUCCESSFULLY get volume details ================>", zap.Reflect("VolumeDetails", volume))
 			} else {
 				ctxLogger.Info("Provider error is ================>", zap.Reflect("ErrorType", userError.GetErrorType(errr)))
-				errr = updateRequestID(errr, string(requestID.Bytes()))
+				errr = updateRequestID(errr, requestID.String())
 				ctxLogger.Info("FAILED to get volume details ================>", zap.Reflect("VolumeID", volumeID), zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -160,7 +160,7 @@ func main() {
 				ctxLogger.Info("Successfully created snapshot on ================>", zap.Reflect("VolumeID", volumeID))
 				ctxLogger.Info("Snapshot details: ", zap.Reflect("Snapshot", snapshot))
 			} else {
-				errr = updateRequestID(errr, string(requestID.Bytes()))
+				errr = updateRequestID(errr, requestID.String())
 				ctxLogger.Info("Failed to create snapshot on ================>", zap.Reflect("VolumeID", volumeID), zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -174,7 +174,7 @@ func main() {
 				ctxLogger.Info("Successfully get snapshot details ================>", zap.Reflect("Snapshot ID", volumeID))
 				ctxLogger.Info("List of snapshots ", zap.Reflect("Snapshots are->", snapshots))
 			} else {
-				errr = updateRequestID(errr, string(requestID.Bytes()))
+				errr = updateRequestID(errr, requestID.String())
 				ctxLogger.Info("Failed to get snapshot details ================>", zap.Reflect("Snapshot ID", volumeID), zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -226,7 +226,7 @@ func main() {
 			if errr == nil {
 				ctxLogger.Info("Successfully ordered volume ================>", zap.Reflect("volumeObj", volumeObj))
 			} else {
-				errr = updateRequestID(errr, string(requestID.Bytes()))
+				errr = updateRequestID(errr, requestID.String())
 				ctxLogger.Info("Failed to order volume ================>", zap.Reflect("StorageType", volume.ProviderType), zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -257,7 +257,7 @@ func main() {
 			if er11 == nil {
 				ctxLogger.Info("Successfully ordered snapshot space ================>", zap.Reflect("Volume ID", volumeID))
 			} else {
-				er11 = updateRequestID(er11, string(requestID.Bytes()))
+				er11 = updateRequestID(er11, requestID.String())
 				ctxLogger.Info("failed to order snapshot space================>", zap.Reflect("Volume ID", volumeID), zap.Reflect("Error", er11))
 			}
 			fmt.Printf("\n\n")
@@ -276,7 +276,7 @@ func main() {
 				ctxLogger.Info("Successfully Created volume from snapshot ================>", zap.Reflect("OriginalVolumeID", volumeID), zap.Reflect("SnapshotID", snapshotID))
 				ctxLogger.Info("New volume from snapshot================>", zap.Reflect("New Volume->", vol))
 			} else {
-				errr = updateRequestID(errr, string(requestID.Bytes()))
+				errr = updateRequestID(errr, requestID.String())
 				ctxLogger.Info("Failed to create volume from snapshot ================>", zap.Reflect("OriginalVolumeID", volumeID), zap.Reflect("SnapshotID", snapshotID), zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -290,7 +290,7 @@ func main() {
 			if er11 == nil {
 				ctxLogger.Info("SUCCESSFULLY deleted volume ================>", zap.Reflect("Volume ID", volumeID))
 			} else {
-				er11 = updateRequestID(er11, string(requestID.Bytes()))
+				er11 = updateRequestID(er11, requestID.String())
 				ctxLogger.Info("FAILED volume deletion================>", zap.Reflect("Volume ID", volumeID), zap.Reflect("Error", er11))
 			}
 			fmt.Printf("\n\n")
@@ -304,7 +304,7 @@ func main() {
 			if er11 == nil {
 				ctxLogger.Info("Successfully deleted snapshot ================>", zap.Reflect("Snapshot ID", snapshotID))
 			} else {
-				er11 = updateRequestID(er11, string(requestID.Bytes()))
+				er11 = updateRequestID(er11, requestID.String())
 				ctxLogger.Info("failed snapshot deletion================>", zap.Reflect("Snapshot ID", snapshotID), zap.Reflect("Error", er11))
 			}
 			fmt.Printf("\n\n")
@@ -314,7 +314,7 @@ func main() {
 			if errr == nil {
 				ctxLogger.Info("SUCCESSFULLY got all snapshots ================>", zap.Reflect("Snapshots", list))
 			} else {
-				errr = updateRequestID(errr, string(requestID.Bytes()))
+				errr = updateRequestID(errr, requestID.String())
 				ctxLogger.Info("FAILED All snapshots ================>", zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -324,7 +324,7 @@ func main() {
 			_, er11 = fmt.Scanf("%s", &volumeID)
 			_, error1 := sess.ListAllSnapshots(volumeID)
 			if error1 != nil {
-				error1 = updateRequestID(error1, string(requestID.Bytes()))
+				error1 = updateRequestID(error1, requestID.String())
 				ctxLogger.Info("Failed to get volumeID", zap.Reflect("Error", error1))
 			}
 		} else if choiceN == 12 {
@@ -351,7 +351,7 @@ func main() {
 			}
 			error1 := sess.AuthorizeVolume(authRequest)
 			if error1 != nil {
-				error1 = updateRequestID(error1, string(requestID.Bytes()))
+				error1 = updateRequestID(error1, requestID.String())
 				ctxLogger.Info("Failed to authorize", zap.Reflect("Error", error1))
 			}
 		} else if choiceN == 13 {
@@ -412,7 +412,7 @@ func main() {
 			if errr == nil {
 				ctxLogger.Info("SUCCESSFULLY created volume...", zap.Reflect("volumeObj", volumeObj))
 			} else {
-				errr = updateRequestID(errr, string(requestID.Bytes()))
+				errr = updateRequestID(errr, requestID.String())
 				ctxLogger.Info("FAILED to create volume...", zap.Reflect("StorageType", volume.ProviderType), zap.Reflect("Error", errr))
 			}
 			fmt.Printf("\n\n")
@@ -427,7 +427,7 @@ func main() {
 			if er11 == nil {
 				ctxLogger.Info("Successfully ordered snapshot space ================>", zap.Reflect("Volume ID", volumeID))
 			} else {
-				er11 = updateRequestID(er11, string(requestID.Bytes()))
+				er11 = updateRequestID(er11, requestID.String())
 				ctxLogger.Info("failed to order snapshot space================>", zap.Reflect("Volume ID", volumeID), zap.Reflect("Error", er11))
 			}
 			fmt.Printf("\n\n")
@@ -444,7 +444,7 @@ func main() {
 			if er11 == nil {
 				ctxLogger.Info("Successfully got VPC volume details ================>", zap.Reflect("VolumeDetail", volumeobj1))
 			} else {
-				er11 = updateRequestID(er11, string(requestID.Bytes()))
+				er11 = updateRequestID(er11, requestID.String())
 				ctxLogger.Info("failed to order snapshot space================>", zap.Reflect("VolumeName", volumeName), zap.Reflect("Error", er11))
 			}
 			fmt.Printf("\n\n")
@@ -485,7 +485,7 @@ func main() {
 						continue
 					}
 				} else {
-					er11 = updateRequestID(er11, string(requestID.Bytes()))
+					er11 = updateRequestID(er11, requestID.String())
 					ctxLogger.Info("failed to list volumes================>", zap.Reflect("Error", er11))
 				}
 				break
@@ -505,7 +505,7 @@ func main() {
 			if er11 == nil {
 				ctxLogger.Info("Successfully expanded volume ================>", zap.Reflect("Volume ID", expandedVolumeSize))
 			} else {
-				er11 = updateRequestID(er11, string(requestID.Bytes()))
+				er11 = updateRequestID(er11, requestID.String())
 				ctxLogger.Info("failed to expand================>", zap.Reflect("Volume ID", volumeID), zap.Reflect("Error", er11))
 			}
 			fmt.Printf("\n\n")

--- a/samples/vpc_create_volume_with_encryption.go
+++ b/samples/vpc_create_volume_with_encryption.go
@@ -87,7 +87,7 @@ func main_test() {
 
 	ctxLogger, _ := getContextLogger()
 	requestID, _ := uid.NewV4()
-	ctxLogger = ctxLogger.With(zap.String("RequestID", string(requestID.Bytes())))
+	ctxLogger = ctxLogger.With(zap.String("RequestID", requestID.String()))
 	sess, _, err := provider_util.OpenProviderSession(conf, providerRegistry, providerName, ctxLogger)
 	if err != nil {
 		ctxLogger.Error("Failed to get session", zap.Reflect("Error", err))
@@ -156,7 +156,7 @@ func main_test() {
 	if err == nil {
 		ctxLogger.Info("SUCCESSFULLY created volume...", zap.Reflect("volumeObj", volumeObj))
 	} else {
-		err = updateRequestID(err, string(requestID.Bytes()))
+		err = updateRequestID(err, requestID.String())
 		ctxLogger.Info("FAILED to create volume...", zap.Reflect("StorageType", volume.ProviderType), zap.Reflect("Error", err))
 	}
 	fmt.Printf("\n\n")

--- a/samples/vpc_create_volume_with_encryption.go
+++ b/samples/vpc_create_volume_with_encryption.go
@@ -22,7 +22,7 @@ import (
 	userError "github.com/IBM/ibmcloud-storage-volume-lib/lib/utils"
 	"github.com/IBM/ibmcloud-storage-volume-lib/provider/local"
 	provider_util "github.com/IBM/ibmcloud-storage-volume-lib/provider/utils"
-	uid "github.com/satori/go.uuid"
+	uid "github.com/gofrs/uuid"
 )
 
 func getContextLogger() (*zap.Logger, zap.AtomicLevel) {
@@ -86,8 +86,8 @@ func main_test() {
 	}
 
 	ctxLogger, _ := getContextLogger()
-	requestID := uid.NewV4().String()
-	ctxLogger = ctxLogger.With(zap.String("RequestID", requestID))
+	requestID, _ := uid.NewV4()
+	ctxLogger = ctxLogger.With(zap.String("RequestID", string(requestID.Bytes())))
 	sess, _, err := provider_util.OpenProviderSession(conf, providerRegistry, providerName, ctxLogger)
 	if err != nil {
 		ctxLogger.Error("Failed to get session", zap.Reflect("Error", err))
@@ -156,7 +156,7 @@ func main_test() {
 	if err == nil {
 		ctxLogger.Info("SUCCESSFULLY created volume...", zap.Reflect("volumeObj", volumeObj))
 	} else {
-		err = updateRequestID(err, requestID)
+		err = updateRequestID(err, string(requestID.Bytes()))
 		ctxLogger.Info("FAILED to create volume...", zap.Reflect("StorageType", volume.ProviderType), zap.Reflect("Error", err))
 	}
 	fmt.Printf("\n\n")


### PR DESCRIPTION
```
 make all
# glide install
go get github.com/pierrre/gotestcover
/bin/sh: 1: [[: not found
golangci-lint run --skip-dirs=e2e
golangci-lint run --disable-all --enable=gofmt --timeout 600s --skip-dirs=e2e
go vet github.com/IBM/ibmcloud-storage-volume-lib/config github.com/IBM/ibmcloud-storage-volume-lib/lib/metrics github.com/IBM/ibmcloud-storage-volume-lib/lib/provider github.com/IBM/ibmcloud-storage-volume-lib/lib/provider/fake github.com/IBM/ibmcloud-storage-volume-lib/lib/utils github.com/IBM/ibmcloud-storage-volume-lib/lib/utils/reasoncode github.com/IBM/ibmcloud-storage-volume-lib/provider/auth github.com/IBM/ibmcloud-storage-volume-lib/provider/local github.com/IBM/ibmcloud-storage-volume-lib/provider/registry github.com/IBM/ibmcloud-storage-volume-lib/provider/utils github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/auth github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/iam github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/iks/provider github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/messages github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/provider github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/client github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/client/fakes github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/client/payload github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/instances github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/instances/fakes github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/models github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/riaas github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/riaas/fakes github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/riaas/test github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/vpcvolume github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/vpcvolume/fakes github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/vpcvolume/vpcvolumefakes 
# x86_64
/root/WORKSPACE//bin/gotestcover -v -race -coverprofile=cover.out github.com/IBM/ibmcloud-storage-volume-lib/config github.com/IBM/ibmcloud-storage-volume-lib/lib/metrics github.com/IBM/ibmcloud-storage-volume-lib/lib/provider github.com/IBM/ibmcloud-storage-volume-lib/lib/provider/fake github.com/IBM/ibmcloud-storage-volume-lib/lib/utils github.com/IBM/ibmcloud-storage-volume-lib/lib/utils/reasoncode github.com/IBM/ibmcloud-storage-volume-lib/provider/auth github.com/IBM/ibmcloud-storage-volume-lib/provider/local github.com/IBM/ibmcloud-storage-volume-lib/provider/registry github.com/IBM/ibmcloud-storage-volume-lib/provider/utils github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/auth github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/iam github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/iks/provider github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/messages github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/provider github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/client github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/client/fakes github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/client/payload github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/instances github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/instances/fakes github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/models github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/riaas github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/riaas/fakes github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/riaas/test github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/vpcvolume github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/vpcvolume/fakes github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/vpcvolume/vpcvolumefakes  -timeout 90m
?   	github.com/IBM/ibmcloud-storage-volume-lib/lib/utils/reasoncode	[no test files]
?   	github.com/IBM/ibmcloud-storage-volume-lib/provider/auth	[no test files]
?   	github.com/IBM/ibmcloud-storage-volume-lib/lib/provider/fake	[no test files]
?   	github.com/IBM/ibmcloud-storage-volume-lib/lib/provider	[no test files]
?   	github.com/IBM/ibmcloud-storage-volume-lib/provider/registry	[no test files]
?   	github.com/IBM/ibmcloud-storage-volume-lib/provider/local	[no test files]
=== RUN   TestSafeStringValue
--- PASS: TestSafeStringValue (0.00s)
=== RUN   TestStringHasValue
--- PASS: TestStringHasValue (0.00s)
=== RUN   TestGetErrorType
--- PASS: TestGetErrorType (0.00s)
=== RUN   TestNewError
=== RUN   TestNewError/Case_ErrorUnclassified
=== RUN   TestNewError/Case_DefaultCode
=== RUN   TestNewError/Case_Wrapped
=== RUN   TestNewError/Case_MultiWrapped
=== RUN   TestNewError/Case_ErrorUnclassified_with_properties
=== RUN   TestNewError/Case_DefaultCode_with_properties
=== RUN   TestNewError/Case_Wrapped_with_properties
=== RUN   TestNewError/Case_MultiWrapped_with_properties
--- PASS: TestNewError (0.00s)
    --- PASS: TestNewError/Case_ErrorUnclassified (0.00s)
    --- PASS: TestNewError/Case_DefaultCode (0.00s)
    --- PASS: TestNewError/Case_Wrapped (0.00s)
    --- PASS: TestNewError/Case_MultiWrapped (0.00s)
    --- PASS: TestNewError/Case_ErrorUnclassified_with_properties (0.00s)
    --- PASS: TestNewError/Case_DefaultCode_with_properties (0.00s)
    --- PASS: TestNewError/Case_Wrapped_with_properties (0.00s)
    --- PASS: TestNewError/Case_MultiWrapped_with_properties (0.00s)
=== RUN   TestNewErrorUnwrapString
--- PASS: TestNewErrorUnwrapString (0.00s)
=== RUN   TestErrorReasonCode
--- PASS: TestErrorReasonCode (0.00s)
=== RUN   TestErrorToFault
--- PASS: TestErrorToFault (0.00s)
=== RUN   TestFaultToError
--- PASS: TestFaultToError (0.00s)
=== RUN   TestSetResponseFault
=== RUN   TestSetResponseFault/not_struct_ptr
=== RUN   TestSetResponseFault/no_fault_field
=== RUN   TestSetResponseFault/string_fault_field
=== RUN   TestSetResponseFault/nil_fault
--- PASS: TestSetResponseFault (0.00s)
    --- PASS: TestSetResponseFault/not_struct_ptr (0.00s)
    --- PASS: TestSetResponseFault/no_fault_field (0.00s)
    --- PASS: TestSetResponseFault/string_fault_field (0.00s)
    --- PASS: TestSetResponseFault/nil_fault (0.00s)
=== RUN   TestZapError
--- PASS: TestZapError (0.00s)
=== RUN   TestMessageError
--- PASS: TestMessageError (0.00s)
=== RUN   TestTimeTracker
    time_tracker_test.go:19: Testing TimeTracker
2022/02/04 05:56:52 TIME TAKEN BY FUNCTION TestFunction IS 7.121µs
--- PASS: TestTimeTracker (0.00s)
PASS
coverage: 75.0% of statements
ok  	github.com/IBM/ibmcloud-storage-volume-lib/lib/utils	0.213s	coverage: 75.0% of statements
=== RUN   TestReadConfig
    config_test.go:66: Testing ReadConfig
{"level":"info","ts":"2022-02-04T05:56:52.590-0800","caller":"config/config.go:55","msg":"parsing conf file","confpath":"test.toml"}
--- PASS: TestReadConfig (0.02s)
=== RUN   TestReadConfigEmptyPath
    config_test.go:75: Testing ReadConfig
{"level":"info","ts":"2022-02-04T05:56:52.612-0800","caller":"config/config.go:55","msg":"parsing conf file","confpath":"/root/WORKSPACE/src/github.com/IBM/ibmcloud-storage-volume-lib/etc/libconfig.toml"}
--- PASS: TestReadConfigEmptyPath (0.01s)
=== RUN   TestParseConfig
    config_test.go:84: Testing config parsing
--- PASS: TestParseConfig (0.00s)
=== RUN   TestParseConfigNoMatch
    config_test.go:95: Testing config parsing false positive
--- PASS: TestParseConfigNoMatch (0.00s)
=== RUN   TestParseConfigNoMatchTwo
    config_test.go:115: Testing config parsing false positive
{"level":"error","ts":"2022-02-04T05:56:52.633-0800","caller":"config/config.go:87","msg":"Failed to parse config file","error":"open test1.toml: no such file or directory"}
--- PASS: TestParseConfigNoMatchTwo (0.00s)
=== RUN   TestGetGoPath
    config_test.go:135: Testing getting GOPATH
--- PASS: TestGetGoPath (0.00s)
=== RUN   TestGetEnv
    config_test.go:145: Testing getting ENV
--- PASS: TestGetEnv (0.00s)
=== RUN   TestGetGoPathNullPath
    config_test.go:155: Testing getting GOPATH NULL Path
--- PASS: TestGetGoPathNullPath (0.00s)
=== RUN   TestGetEtcPath
    config_test.go:165: Testing GetEtcPath
--- PASS: TestGetEtcPath (0.00s)
=== RUN   TestGetConfPath
    config_test.go:174: Testing GetEtcPath
--- PASS: TestGetConfPath (0.00s)
=== RUN   TestGetConfPathWithEnv
    config_test.go:183: Testing GetEtcPath
--- PASS: TestGetConfPathWithEnv (0.00s)
=== RUN   TestGetDefaultConfPath
    config_test.go:193: Testing GetEtcPath
--- PASS: TestGetDefaultConfPath (0.00s)
=== RUN   TestGetConfPathDir
    config_test.go:202: Testing GetConfPathDir
--- PASS: TestGetConfPathDir (0.00s)
=== RUN   TestGeneralCAHttpClient
    tls_test.go:20: Testing GeneralCAHttpClient
--- PASS: TestGeneralCAHttpClient (0.00s)
=== RUN   TestGeneralCAHttpClientWithTimeout
    tls_test.go:28: Testing GeneralCAHttpClientWithTimeout
--- PASS: TestGeneralCAHttpClientWithTimeout (0.00s)
PASS
coverage: 96.8% of statements
ok  	github.com/IBM/ibmcloud-storage-volume-lib/config	0.407s	coverage: 96.8% of statements
?   	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/messages	[no test files]
?   	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/client/fakes	[no test files]
?   	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/client/payload	[no test files]
=== RUN   TestForIaaSAPIKey
--- PASS: TestForIaaSAPIKey (0.00s)
=== RUN   TestNewContextCredentialsFactory
--- PASS: TestNewContextCredentialsFactory (0.00s)
PASS
coverage: 20.6% of statements
ok  	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/auth	0.217s	coverage: 20.6% of statements
=== RUN   TestClient
=== RUN   TestClient/creates_invokable_requests_from_static_operations_(GET)
=== RUN   TestClient/creates_invokable_requests_from_static_operations_(POST)
=== RUN   TestClient/encodes_query_parameters
=== RUN   TestClient/encodes_multipart_form_data
=== RUN   TestClient/single_error
=== RUN   TestClient/multiple_errors
--- PASS: TestClient (0.07s)
    --- PASS: TestClient/creates_invokable_requests_from_static_operations_(GET) (0.01s)
    --- PASS: TestClient/creates_invokable_requests_from_static_operations_(POST) (0.02s)
    --- PASS: TestClient/encodes_query_parameters (0.01s)
    --- PASS: TestClient/encodes_multipart_form_data (0.02s)
    --- PASS: TestClient/single_error (0.01s)
    --- PASS: TestClient/multiple_errors (0.01s)
=== RUN   TestDebugMode
=== RUN   TestDebugMode/records_the_request_method_and_resource
=== RUN   TestDebugMode/records_the_request_body
=== RUN   TestDebugMode/records_the_response_code
=== RUN   TestDebugMode/records_the_response_body
=== RUN   TestDebugMode/redacts_the_Authorizration_header_value
--- PASS: TestDebugMode (0.04s)
    --- PASS: TestDebugMode/records_the_request_method_and_resource (0.02s)
    --- PASS: TestDebugMode/records_the_request_body (0.01s)
    --- PASS: TestDebugMode/records_the_response_code (0.01s)
    --- PASS: TestDebugMode/records_the_response_body (0.01s)
    --- PASS: TestDebugMode/redacts_the_Authorizration_header_value (0.01s)
=== RUN   TestOperationURLProcessing
=== RUN   TestOperationURLProcessing/absolute_path
=== RUN   TestOperationURLProcessing/relative_path_base_does_not_end_with_slash
=== RUN   TestOperationURLProcessing/relative_path_when_base_ends_with_slash
=== RUN   TestOperationURLProcessing/relative_path_parent
=== RUN   TestOperationURLProcessing/relative_path_with_.._beyond_root
=== RUN   TestOperationURLProcessing/broken_base_URL
=== RUN   TestOperationURLProcessing/broken_relative_path
--- PASS: TestOperationURLProcessing (0.00s)
    --- PASS: TestOperationURLProcessing/absolute_path (0.00s)
    --- PASS: TestOperationURLProcessing/relative_path_base_does_not_end_with_slash (0.00s)
    --- PASS: TestOperationURLProcessing/relative_path_when_base_ends_with_slash (0.00s)
    --- PASS: TestOperationURLProcessing/relative_path_parent (0.00s)
    --- PASS: TestOperationURLProcessing/relative_path_with_.._beyond_root (0.00s)
    --- PASS: TestOperationURLProcessing/broken_base_URL (0.00s)
    --- PASS: TestOperationURLProcessing/broken_relative_path (0.00s)
=== RUN   TestWithPathParameter
--- PASS: TestWithPathParameter (0.00s)
=== RUN   TestWithQueryValue
--- PASS: TestWithQueryValue (0.00s)
=== RUN   TestParams
--- PASS: TestParams (0.00s)
PASS
coverage: 80.8% of statements
ok  	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/client	0.406s	coverage: 80.8% of statements
=== RUN   Test_IKSExchangeRefreshTokenForAccessToken_Success
{"L":"INFO","T":"2022-02-04T05:56:57.293-0800","C":"iam/token_exchange_iks.go:106","M":"In tokenExchangeIKSRequest's sendTokenExchangeRequest()"}
{"L":"INFO","T":"2022-02-04T05:56:57.293-0800","C":"iam/token_exchange_iks.go:125","M":"Sending IAM token exchange request to container api server"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.299-0800","C":"iam/token_exchange_iks.go:135","M":"IAM token exchange request successful"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.299-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","shouldStop":true}
--- PASS: Test_IKSExchangeRefreshTokenForAccessToken_Success (0.01s)
=== RUN   Test_IKSExchangeRefreshTokenForAccessToken_FailedDuringRequest
{"L":"INFO","T":"2022-02-04T05:56:57.300-0800","C":"iam/token_exchange_iks.go:106","M":"In tokenExchangeIKSRequest's sendTokenExchangeRequest()"}
{"L":"INFO","T":"2022-02-04T05:56:57.300-0800","C":"iam/token_exchange_iks.go:125","M":"Sending IAM token exchange request to container api server"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.303-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed: did not work","shouldStop":true}
--- PASS: Test_IKSExchangeRefreshTokenForAccessToken_FailedDuringRequest (0.00s)
=== RUN   Test_IKSExchangeRefreshTokenForAccessToken_FailedDuringRequest_no_message
{"L":"INFO","T":"2022-02-04T05:56:57.303-0800","C":"iam/token_exchange_iks.go:106","M":"In tokenExchangeIKSRequest's sendTokenExchangeRequest()"}
{"L":"INFO","T":"2022-02-04T05:56:57.303-0800","C":"iam/token_exchange_iks.go:125","M":"Sending IAM token exchange request to container api server"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.318-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"Unexpected IAM token exchange response","shouldStop":true}
--- PASS: Test_IKSExchangeRefreshTokenForAccessToken_FailedDuringRequest_no_message (0.02s)
=== RUN   Test_IKSExchangeRefreshTokenForAccessToken_FailedWrongApiUrl
{"L":"INFO","T":"2022-02-04T05:56:57.318-0800","C":"iam/token_exchange_iks.go:106","M":"In tokenExchangeIKSRequest's sendTokenExchangeRequest()"}
{"L":"INFO","T":"2022-02-04T05:56:57.319-0800","C":"iam/token_exchange_iks.go:125","M":"Sending IAM token exchange request to container api server"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.319-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed","shouldStop":true}
--- PASS: Test_IKSExchangeRefreshTokenForAccessToken_FailedWrongApiUrl (0.00s)
=== RUN   Test_IKSExchangeRefreshTokenForAccessToken_FailedRequesting_unclassified_error
{"L":"INFO","T":"2022-02-04T05:56:57.319-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.319-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.320-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed","shouldStop":true}
--- PASS: Test_IKSExchangeRefreshTokenForAccessToken_FailedRequesting_unclassified_error (0.00s)
=== RUN   Test_IKSExchangeIAMAPIKeyForAccessToken
=== RUN   Test_IKSExchangeIAMAPIKeyForAccessToken/client_error
{"L":"INFO","T":"2022-02-04T05:56:57.320-0800","C":"iam/token_exchange_iks.go:106","M":"In tokenExchangeIKSRequest's sendTokenExchangeRequest()"}
{"L":"INFO","T":"2022-02-04T05:56:57.320-0800","C":"iam/token_exchange_iks.go:125","M":"Sending IAM token exchange request to container api server"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.325-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed","shouldStop":true}
=== RUN   Test_IKSExchangeIAMAPIKeyForAccessToken/success_200
{"L":"INFO","T":"2022-02-04T05:56:57.326-0800","C":"iam/token_exchange_iks.go:106","M":"In tokenExchangeIKSRequest's sendTokenExchangeRequest()"}
{"L":"INFO","T":"2022-02-04T05:56:57.326-0800","C":"iam/token_exchange_iks.go:125","M":"Sending IAM token exchange request to container api server"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.331-0800","C":"iam/token_exchange_iks.go:135","M":"IAM token exchange request successful"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.331-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","shouldStop":true}
=== RUN   Test_IKSExchangeIAMAPIKeyForAccessToken/unauthorised
{"L":"INFO","T":"2022-02-04T05:56:57.332-0800","C":"iam/token_exchange_iks.go:106","M":"In tokenExchangeIKSRequest's sendTokenExchangeRequest()"}
{"L":"INFO","T":"2022-02-04T05:56:57.332-0800","C":"iam/token_exchange_iks.go:125","M":"Sending IAM token exchange request to container api server"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.339-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed: not authorised","shouldStop":true}
=== RUN   Test_IKSExchangeIAMAPIKeyForAccessToken/no_error_message
{"L":"INFO","T":"2022-02-04T05:56:57.340-0800","C":"iam/token_exchange_iks.go:106","M":"In tokenExchangeIKSRequest's sendTokenExchangeRequest()"}
{"L":"INFO","T":"2022-02-04T05:56:57.341-0800","C":"iam/token_exchange_iks.go:125","M":"Sending IAM token exchange request to container api server"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.343-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"Unexpected IAM token exchange response","shouldStop":true}
--- PASS: Test_IKSExchangeIAMAPIKeyForAccessToken (0.02s)
    --- PASS: Test_IKSExchangeIAMAPIKeyForAccessToken/client_error (0.01s)
    --- PASS: Test_IKSExchangeIAMAPIKeyForAccessToken/success_200 (0.01s)
    --- PASS: Test_IKSExchangeIAMAPIKeyForAccessToken/unauthorised (0.01s)
    --- PASS: Test_IKSExchangeIAMAPIKeyForAccessToken/no_error_message (0.00s)
=== RUN   Test_ExchangeRefreshTokenForAccessToken_Success
{"L":"INFO","T":"2022-02-04T05:56:57.343-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.344-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.346-0800","C":"iam/token_exchange.go:195","M":"IAM token exchange request successful"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.346-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","shouldStop":true}
--- PASS: Test_ExchangeRefreshTokenForAccessToken_Success (0.00s)
=== RUN   Test_ExchangeRefreshTokenForAccessToken_FailedDuringRequest
{"L":"INFO","T":"2022-02-04T05:56:57.347-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.347-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.349-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed: did not work","shouldStop":true}
--- PASS: Test_ExchangeRefreshTokenForAccessToken_FailedDuringRequest (0.00s)
=== RUN   Test_ExchangeRefreshTokenForAccessToken_FailedDuringRequest_no_message
{"L":"INFO","T":"2022-02-04T05:56:57.351-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.351-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.360-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"Unexpected IAM token exchange response","shouldStop":true}
--- PASS: Test_ExchangeRefreshTokenForAccessToken_FailedDuringRequest_no_message (0.01s)
=== RUN   Test_ExchangeRefreshTokenForAccessToken_FailedNoIamUrl
{"L":"INFO","T":"2022-02-04T05:56:57.361-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.361-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.361-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed","shouldStop":true}
--- PASS: Test_ExchangeRefreshTokenForAccessToken_FailedNoIamUrl (0.00s)
=== RUN   Test_ExchangeRefreshTokenForAccessToken_FailedRequesting_empty_body
{"L":"INFO","T":"2022-02-04T05:56:57.362-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.362-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.365-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed","shouldStop":true}
--- PASS: Test_ExchangeRefreshTokenForAccessToken_FailedRequesting_empty_body (0.00s)
=== RUN   TestNewTokenExchangeServiceWithClient
--- PASS: TestNewTokenExchangeServiceWithClient (0.00s)
=== RUN   TestExchangeIAMAPIKeyForIMSToken
{"L":"INFO","T":"2022-02-04T05:56:57.366-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.366-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.371-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed","shouldStop":true}
--- PASS: TestExchangeIAMAPIKeyForIMSToken (0.01s)
=== RUN   Test_ExchangeAccessTokenForIMSToken_Success
{"L":"INFO","T":"2022-02-04T05:56:57.372-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.372-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.375-0800","C":"iam/token_exchange.go:195","M":"IAM token exchange request successful"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.375-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","shouldStop":true}
--- PASS: Test_ExchangeAccessTokenForIMSToken_Success (0.00s)
=== RUN   Test_ExchangeAccessTokenForIMSToken_FailedDuringRequest
{"L":"INFO","T":"2022-02-04T05:56:57.376-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.376-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.381-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed: did not work","shouldStop":true}
--- PASS: Test_ExchangeAccessTokenForIMSToken_FailedDuringRequest (0.01s)
=== RUN   Test_ExchangeAccessTokenForIMSToken_FailedAccountLocked
{"L":"INFO","T":"2022-02-04T05:56:57.382-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.382-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.388-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"Infrastructure account is temporarily locked","shouldStop":true}
--- PASS: Test_ExchangeAccessTokenForIMSToken_FailedAccountLocked (0.01s)
=== RUN   Test_ExchangeAccessTokenForIMSToken_FailedDuringRequest_no_message
{"L":"INFO","T":"2022-02-04T05:56:57.389-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.389-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.403-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"Unexpected IAM token exchange response","shouldStop":true}
--- PASS: Test_ExchangeAccessTokenForIMSToken_FailedDuringRequest_no_message (0.01s)
=== RUN   Test_ExchangeAccessTokenForIMSToken_FailedRequesting_empty_body
{"L":"INFO","T":"2022-02-04T05:56:57.404-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.404-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.406-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed","shouldStop":true}
--- PASS: Test_ExchangeAccessTokenForIMSToken_FailedRequesting_empty_body (0.00s)
=== RUN   Test_ExchangeIAMAPIKeyForAccessToken
=== RUN   Test_ExchangeIAMAPIKeyForAccessToken/client_error
{"L":"INFO","T":"2022-02-04T05:56:57.407-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.407-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.409-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed","shouldStop":true}
=== RUN   Test_ExchangeIAMAPIKeyForAccessToken/success_200
{"L":"INFO","T":"2022-02-04T05:56:57.409-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.409-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.430-0800","C":"iam/token_exchange.go:195","M":"IAM token exchange request successful"}
{"L":"DEBUG","T":"2022-02-04T05:56:57.430-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","shouldStop":true}
=== RUN   Test_ExchangeIAMAPIKeyForAccessToken/unauthorised
{"L":"INFO","T":"2022-02-04T05:56:57.431-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.431-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.434-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"IAM token exchange request failed: not authorised","shouldStop":true}
=== RUN   Test_ExchangeIAMAPIKeyForAccessToken/no_error_message
{"L":"INFO","T":"2022-02-04T05:56:57.434-0800","C":"iam/token_exchange.go:180","M":"Sending IAM token exchange request"}
{"L":"INFO","T":"2022-02-04T05:56:57.434-0800","C":"iam/token_exchange.go:181","M":"Request is:=================","Request":{}}
{"L":"DEBUG","T":"2022-02-04T05:56:57.438-0800","C":"utils/error_utils.go:151","M":"Retry Function Result","error":"Unexpected IAM token exchange response","shouldStop":true}
--- PASS: Test_ExchangeIAMAPIKeyForAccessToken (0.03s)
    --- PASS: Test_ExchangeIAMAPIKeyForAccessToken/client_error (0.00s)
    --- PASS: Test_ExchangeIAMAPIKeyForAccessToken/success_200 (0.02s)
    --- PASS: Test_ExchangeIAMAPIKeyForAccessToken/unauthorised (0.00s)
    --- PASS: Test_ExchangeIAMAPIKeyForAccessToken/no_error_message (0.00s)
=== RUN   Test_GetIAMAccountIDFromAccessToken
=== RUN   Test_GetIAMAccountIDFromAccessToken/fake_token
2022-02-04T05:56:57.440-0800	DEBUG	iam/token_validation.go:41	Access token parsed	{"haveClaims": true, "valid": true}
2022-02-04T05:56:57.440-0800	DEBUG	iam/token_validation.go:49	GetIAMAccountIDFromAccessToken	{"claims.Account.Bss": "12345"}
--- PASS: Test_GetIAMAccountIDFromAccessToken (0.00s)
    --- PASS: Test_GetIAMAccountIDFromAccessToken/fake_token (0.00s)
PASS
coverage: 94.4% of statements
ok  	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/iam	0.355s	coverage: 94.4% of statements
?   	github.com/IBM/ibmcloud-storage-volume-lib/lib/metrics	[no test files]
?   	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/models	[no test files]
?   	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/instances/fakes	[no test files]
?   	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/riaas/test	[no test files]
?   	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/riaas/fakes	[no test files]
?   	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/vpcvolume/vpcvolumefakes	[no test files]
=== RUN   TestConfig
--- PASS: TestConfig (0.00s)
=== RUN   TestLogin
--- PASS: TestLogin (0.00s)
=== RUN   TestNewSession
--- PASS: TestNewSession (0.00s)
=== RUN   TestVolumeService
--- PASS: TestVolumeService (0.00s)
=== RUN   TestSnapshotService
--- PASS: TestSnapshotService (0.00s)
=== RUN   TestVolumeAttachService
--- PASS: TestVolumeAttachService (0.00s)
PASS
coverage: 77.4% of statements
ok  	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/riaas	0.185s	coverage: 77.4% of statements
?   	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/vpcvolume/fakes	[no test files]
=== RUN   TestNewProvider
--- PASS: TestNewProvider (0.00s)
=== RUN   TestGetTestProvider
--- PASS: TestGetTestProvider (0.00s)
=== RUN   TestOpenSession
--- PASS: TestOpenSession (0.01s)
=== RUN   TestGetTestOpenSession
--- PASS: TestGetTestOpenSession (0.00s)
=== RUN   TestUpdateVolume
=== RUN   TestUpdateVolume/Volume_Update_Success
=== RUN   TestUpdateVolume/VolumeID_Empty
=== RUN   TestUpdateVolume/Volume_Provider_Empty
--- PASS: TestUpdateVolume (0.01s)
    --- PASS: TestUpdateVolume/Volume_Update_Success (0.00s)
    --- PASS: TestUpdateVolume/VolumeID_Empty (0.00s)
    --- PASS: TestUpdateVolume/Volume_Provider_Empty (0.00s)
PASS
coverage: 51.1% of statements
ok  	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/iks/provider	0.205s	coverage: 51.1% of statements
=== RUN   TestAttachVolume
=== RUN   TestAttachVolume/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:00.878-0800","caller":"instances/attach_volume_test.go:86","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:00.878-0800","caller":"instances/attach_volume.go:39","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:41605/v1/instances/%7Binstance-id%7D/volume_attachments?version=2019-07-02","Payload":{"name":"volume attachment","volume":{"id":"volume-id","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"AttachVolume","Method":"POST","PathPattern":"v1/instances/{instance-id}/volume_attachments"},"PathParameters":"testinstance"}
{"level":"info","ts":"2022-02-04T05:57:00.893-0800","caller":"instances/attach_volume.go:45","msg":"Successfuly attached the volume"}
{"level":"info","ts":"2022-02-04T05:57:00.893-0800","caller":"metrics/metrics.go:65","msg":"Time to complete","VolumeAttachService.AttachVolume":0.014979829}
2022/02/04 05:57:00 TIME TAKEN BY FUNCTION VolumeAttachService.AttachVolume IS 15.138988ms
{"level":"info","ts":"2022-02-04T05:57:00.894-0800","caller":"instances/attach_volume_test.go:91","msg":"Volume attachment details","volumeAttachment":{}}
=== RUN   TestAttachVolume/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:00.895-0800","caller":"instances/attach_volume_test.go:86","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:00.895-0800","caller":"instances/attach_volume.go:39","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:35347/v1/instances/%7Binstance-id%7D/volume_attachments?version=2019-07-02","Payload":{"name":"volume attachment","volume":{"id":"volume-id","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"AttachVolume","Method":"POST","PathPattern":"v1/instances/{instance-id}/volume_attachments"},"PathParameters":"testinstance"}
{"level":"info","ts":"2022-02-04T05:57:00.904-0800","caller":"metrics/metrics.go:65","msg":"Time to complete","VolumeAttachService.AttachVolume":0.009042331}
2022/02/04 05:57:00 TIME TAKEN BY FUNCTION VolumeAttachService.AttachVolume IS 9.161121ms
{"level":"info","ts":"2022-02-04T05:57:00.904-0800","caller":"instances/attach_volume_test.go:91","msg":"Volume attachment details","volumeAttachment":null}
=== RUN   TestAttachVolume/Verify_that_the_volume_attachment_is_done_correctly
{"level":"info","ts":"2022-02-04T05:57:00.905-0800","caller":"instances/attach_volume_test.go:86","msg":"Test case being executed","testcase":"Verify that the volume attachment is done correctly"}
{"level":"info","ts":"2022-02-04T05:57:00.905-0800","caller":"instances/attach_volume.go:39","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:34041/v1/instances/%7Binstance-id%7D/volume_attachments?version=2019-07-02","Payload":{"name":"volume attachment","volume":{"id":"volume-id","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"AttachVolume","Method":"POST","PathPattern":"v1/instances/{instance-id}/volume_attachments"},"PathParameters":"testinstance"}
{"level":"info","ts":"2022-02-04T05:57:00.914-0800","caller":"instances/attach_volume.go:45","msg":"Successfuly attached the volume"}
{"level":"info","ts":"2022-02-04T05:57:00.915-0800","caller":"metrics/metrics.go:65","msg":"Time to complete","VolumeAttachService.AttachVolume":0.009232419}
2022/02/04 05:57:00 TIME TAKEN BY FUNCTION VolumeAttachService.AttachVolume IS 9.372001ms
{"level":"info","ts":"2022-02-04T05:57:00.915-0800","caller":"instances/attach_volume_test.go:91","msg":"Volume attachment details","volumeAttachment":{"id":"volume attachment id","name":"volume attachment","device":{"id":"xvdc"},"volume":{"id":"volume-id","name":"volume-name","capacity":10,"iops":3000,"status":"pending"}}}
--- PASS: TestAttachVolume (0.04s)
    --- PASS: TestAttachVolume/Verify_that_the_correct_endpoint_is_invoked (0.02s)
    --- PASS: TestAttachVolume/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestAttachVolume/Verify_that_the_volume_attachment_is_done_correctly (0.01s)
=== RUN   TestDetachVolume
=== RUN   TestDetachVolume/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:00.917-0800","caller":"instances/detach_volume_test.go:83","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:00.917-0800","caller":"instances/detach_volume.go:41","msg":"Equivalent curl command details","URL":"http://127.0.0.1:45955/v1/instances/testinstance/volume_attachments/volumeattachmentid?version=2019-07-02","volumeAttachmentTemplate":{"id":"volumeattachmentid","name":"volumeattachment","volume":{"id":"volume-id","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"DetachVolume","Method":"DELETE","PathPattern":"v1/instances/{instance-id}/volume_attachments/{id}"}}
{"level":"info","ts":"2022-02-04T05:57:00.917-0800","caller":"instances/detach_volume.go:42","msg":"Pathparameters","instance-id":"testinstance","id":"volumeattachmentid"}
{"level":"info","ts":"2022-02-04T05:57:00.923-0800","caller":"instances/detach_volume.go:53","msg":"Exit DetachVolume","error":"Unknown error"}
{"level":"info","ts":"2022-02-04T05:57:00.923-0800","caller":"metrics/metrics.go:65","msg":"Time to complete","VolumeAttachService.DetachVolume":0.006185233}
2022/02/04 05:57:00 TIME TAKEN BY FUNCTION VolumeAttachService.DetachVolume IS 6.262716ms
=== RUN   TestDetachVolume/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:00.924-0800","caller":"instances/detach_volume_test.go:83","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:00.924-0800","caller":"instances/detach_volume.go:41","msg":"Equivalent curl command details","URL":"http://127.0.0.1:46219/v1/instances/testinstance/volume_attachments/volumeattachmentid?version=2019-07-02","volumeAttachmentTemplate":{"id":"volumeattachmentid","name":"volumeattachment","volume":{"id":"volume-id","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"DetachVolume","Method":"DELETE","PathPattern":"v1/instances/{instance-id}/volume_attachments/{id}"}}
{"level":"info","ts":"2022-02-04T05:57:00.925-0800","caller":"instances/detach_volume.go:42","msg":"Pathparameters","instance-id":"testinstance","id":"volumeattachmentid"}
{"level":"error","ts":"2022-02-04T05:57:00.935-0800","caller":"instances/detach_volume.go:46","msg":"Error occured while deleting volume attachment","error":"Trace Code:, testerr Please check "}
{"level":"info","ts":"2022-02-04T05:57:00.935-0800","caller":"instances/detach_volume.go:49","msg":"Exit DetachVolume","resp":404,"error":"Trace Code:, testerr Please check ","error":"Trace Code:, testerr Please check "}
{"level":"info","ts":"2022-02-04T05:57:00.935-0800","caller":"metrics/metrics.go:65","msg":"Time to complete","VolumeAttachService.DetachVolume":0.010799433}
2022/02/04 05:57:00 TIME TAKEN BY FUNCTION VolumeAttachService.DetachVolume IS 10.864128ms
=== RUN   TestDetachVolume/Verify_that_the_volume_detachment_is_done_correctly
{"level":"info","ts":"2022-02-04T05:57:00.938-0800","caller":"instances/detach_volume_test.go:83","msg":"Test case being executed","testcase":"Verify that the volume detachment is done correctly"}
{"level":"info","ts":"2022-02-04T05:57:00.938-0800","caller":"instances/detach_volume.go:41","msg":"Equivalent curl command details","URL":"http://127.0.0.1:43933/v1/instances/testinstance/volume_attachments/volumeattachmentid?version=2019-07-02","volumeAttachmentTemplate":{"id":"volumeattachmentid","name":"volumeattachment","volume":{"id":"volume-id","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"DetachVolume","Method":"DELETE","PathPattern":"v1/instances/{instance-id}/volume_attachments/{id}"}}
{"level":"info","ts":"2022-02-04T05:57:00.939-0800","caller":"instances/detach_volume.go:42","msg":"Pathparameters","instance-id":"testinstance","id":"volumeattachmentid"}
{"level":"info","ts":"2022-02-04T05:57:00.945-0800","caller":"instances/detach_volume.go:53","msg":"Exit DetachVolume","error":"Unknown error"}
{"level":"info","ts":"2022-02-04T05:57:00.945-0800","caller":"metrics/metrics.go:65","msg":"Time to complete","VolumeAttachService.DetachVolume":0.006535672}
2022/02/04 05:57:00 TIME TAKEN BY FUNCTION VolumeAttachService.DetachVolume IS 6.634361ms
--- PASS: TestDetachVolume (0.03s)
    --- PASS: TestDetachVolume/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestDetachVolume/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestDetachVolume/Verify_that_the_volume_detachment_is_done_correctly (0.01s)
=== RUN   TestGetVolumeAttachment
=== RUN   TestGetVolumeAttachment/Verify_that_the_get_volume_attachment_is_done_correctly
{"level":"info","ts":"2022-02-04T05:57:00.949-0800","caller":"instances/get_volume_attachment_test.go:76","msg":"Test case being executed","testcase":"Verify that the get volume attachment is done correctly"}
{"level":"info","ts":"2022-02-04T05:57:00.950-0800","caller":"instances/get_volume_attachment.go:39","msg":"Equivalent curl command details","URL":"http://127.0.0.1:44205/v1/instances/%7Binstance-id%7D/volume_attachments/%7Bid%7D?version=2019-07-02","volumeAttachmentTemplate":{"id":"volumeattachmentid","name":"volumeattachment","volume":{"id":"volume-id","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"GetVolumeAttachment","Method":"GET","PathPattern":"v1/instances/{instance-id}/volume_attachments/{id}"}}
{"level":"info","ts":"2022-02-04T05:57:00.950-0800","caller":"instances/get_volume_attachment.go:40","msg":"Pathparameters","instance-id":"testinstance","id":"volumeattachmentid"}
{"level":"info","ts":"2022-02-04T05:57:00.957-0800","caller":"instances/get_volume_attachment.go:49","msg":"Successfuly retrieved the volume attachment","volumeAttachment":{"id":"volumeattachmentid","name":"volume attachment","device":{"id":"xvdc"},"volume":{"id":"volume-id","name":"volume-name","capacity":10,"iops":3000,"status":"pending"}}}
{"level":"info","ts":"2022-02-04T05:57:00.957-0800","caller":"metrics/metrics.go:65","msg":"Time to complete","VolumeAttachService.GetVolumeAttachment":0.007976006}
2022/02/04 05:57:00 TIME TAKEN BY FUNCTION VolumeAttachService.GetVolumeAttachment IS 8.128941ms
--- PASS: TestGetVolumeAttachment (0.01s)
    --- PASS: TestGetVolumeAttachment/Verify_that_the_get_volume_attachment_is_done_correctly (0.01s)
=== RUN   TestIKSAttachVolume
{"level":"info","ts":"2022-02-04T05:57:00.959-0800","caller":"instances/iks_attach_volume.go:41","msg":"Equivalent curl command and query parameters","URL":"http://127.0.0.1:36493/v2/storage/vpc/createAttachment?cluster=testcluster&version=2019-07-02&volumeID=volume-id&worker=testinstance","Payload":{"name":"volume attachment","clusterID":"testcluster","volume":{"id":"volume-id","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"AttachVolume","Method":"POST","PathPattern":"v2/storage/vpc/createAttachment"},"cluster":"testcluster","worker":"testinstance","volumeID":"volume-id"}
{"level":"info","ts":"2022-02-04T05:57:00.974-0800","caller":"instances/iks_attach_volume.go:48","msg":"Successfuly attached the volume"}
2022/02/04 05:57:00 TIME TAKEN BY FUNCTION IKS AttachVolume IS 14.862575ms
{"level":"info","ts":"2022-02-04T05:57:00.974-0800","caller":"instances/iks_attach_volume_test.go:55","msg":"Volume attachment details","volumeAttachment":{"id":"volume attachment id","name":"volume attachment","device":{"id":"xvdc"},"volume":{"id":"volume-id","name":"volume-name","capacity":10,"iops":3000,"status":"pending"}}}
--- PASS: TestIKSAttachVolume (0.02s)
=== RUN   TestIKSDetachVolume
{"level":"info","ts":"2022-02-04T05:57:00.975-0800","caller":"instances/iks_detach_volume.go:39","msg":"Equivalent curl command and query parameters","URL":"http://127.0.0.1:46021/v2/storage/vpc/deleteAttachment?cluster=testcluster&version=2019-07-02&volumeAttachmentID=volume+attachment+id&worker=testinstance","volumeAttachmentTemplate":{"id":"volume attachment id","name":"volume attachment","clusterID":"testcluster","volume":{"id":"volume-id","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"DetachVolume","Method":"DELETE","PathPattern":"v2/storage/vpc/deleteAttachment"},"cluster":"testcluster","worker":"testinstance","volumeAttachmentID":"volume attachment id"}
{"level":"info","ts":"2022-02-04T05:57:00.985-0800","caller":"instances/iks_detach_volume.go:50","msg":"Successfuly deleted the volume attachment"}
2022/02/04 05:57:00 TIME TAKEN BY FUNCTION IKS DetachVolume IS 10.374645ms
--- PASS: TestIKSDetachVolume (0.01s)
=== RUN   TestIKSGetVolumeAttachment
{"level":"info","ts":"2022-02-04T05:57:00.986-0800","caller":"instances/iks_get_volume_attachment.go:39","msg":"Equivalent curl command and query parameters","URL":"http://127.0.0.1:45323/v2/storage/vpc/getAttachment?cluster=testcluster&version=2019-07-02&volumeAttachmentID=volumeattachmentid&worker=testinstance","cluster":"testcluster","worker":"testinstance","volumeAttachmentID":"volumeattachmentid"}
{"level":"info","ts":"2022-02-04T05:57:00.992-0800","caller":"instances/iks_get_volume_attachment.go:46","msg":"Successfuly retrieved the volume attachment","volumeAttachment":{"id":"volumeattachmentid","name":"volume attachment","device":{"id":"xvdc"},"volume":{"id":"volume-id","name":"volume-name","capacity":10,"iops":3000,"status":"pending"}}}
2022/02/04 05:57:00 TIME TAKEN BY FUNCTION IKS GetVolumeAttachment IS 6.127352ms
--- PASS: TestIKSGetVolumeAttachment (0.01s)
=== RUN   TestIKSListVolumeAttachment
{"level":"info","ts":"2022-02-04T05:57:00.993-0800","caller":"instances/iks_list_volume_attachments.go:39","msg":"Equivalent curl command and query parameters","URL":"http://127.0.0.1:41609/v2/storage/vpc/getAttachmentsList?cluster=testcluster&version=2019-07-02&worker=testinstance","volumeAttachmentTemplate":{"id":"volumeattachmentid","name":"attachment-volume-id","clusterID":"testcluster","volume":{"id":"volume-id","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"ListVolumeAttachment","Method":"GET","PathPattern":"v2/storage/vpc/getAttachmentsList"},"cluster":"testcluster","worker":"testinstance"}
{"level":"info","ts":"2022-02-04T05:57:00.999-0800","caller":"instances/iks_list_volume_attachments.go:46","msg":"Successfuly retrieved the volume attachments"}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION IKS ListVolumeAttachments IS 6.65106ms
--- PASS: TestIKSListVolumeAttachment (0.01s)
=== RUN   TestListVolumeAttachment
=== RUN   TestListVolumeAttachment/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.001-0800","caller":"instances/list_volume_attachments_test.go:81","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.001-0800","caller":"instances/list_volume_attachments.go:40","msg":"Equivalent curl command details","URL":"http://127.0.0.1:32897/v1/instances/%7Binstance-id%7D/volume_attachments?version=2019-07-02","volumeAttachmentTemplate":{"name":"volume attachment","volume":{"id":"volume-id1","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"ListVolumeAttachment","Method":"GET","PathPattern":"v1/instances/{instance-id}/volume_attachments"}}
{"level":"info","ts":"2022-02-04T05:57:01.006-0800","caller":"instances/list_volume_attachments.go:48","msg":"Successfuly retrieved the volume attachments"}
{"level":"info","ts":"2022-02-04T05:57:01.006-0800","caller":"metrics/metrics.go:65","msg":"Time to complete","VolumeAttachService.ListVolumeAttachments":0.004749802}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION VolumeAttachService.ListVolumeAttachments IS 4.882855ms
=== RUN   TestListVolumeAttachment/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.007-0800","caller":"instances/list_volume_attachments_test.go:81","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.007-0800","caller":"instances/list_volume_attachments.go:40","msg":"Equivalent curl command details","URL":"http://127.0.0.1:33765/v1/instances/%7Binstance-id%7D/volume_attachments?version=2019-07-02","volumeAttachmentTemplate":{"name":"volume attachment","volume":{"id":"volume-id1","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"ListVolumeAttachment","Method":"GET","PathPattern":"v1/instances/{instance-id}/volume_attachments"}}
{"level":"error","ts":"2022-02-04T05:57:01.012-0800","caller":"instances/list_volume_attachments.go:45","msg":"Error occured while getting volume attachments list","error":"Trace Code:, testerr Please check "}
{"level":"info","ts":"2022-02-04T05:57:01.012-0800","caller":"metrics/metrics.go:65","msg":"Time to complete","VolumeAttachService.ListVolumeAttachments":0.00509894}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION VolumeAttachService.ListVolumeAttachments IS 5.222038ms
=== RUN   TestListVolumeAttachment/Verify_that_the_volume_attachment_is_done_correctly
{"level":"info","ts":"2022-02-04T05:57:01.013-0800","caller":"instances/list_volume_attachments_test.go:81","msg":"Test case being executed","testcase":"Verify that the volume attachment is done correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.013-0800","caller":"instances/list_volume_attachments.go:40","msg":"Equivalent curl command details","URL":"http://127.0.0.1:37075/v1/instances/%7Binstance-id%7D/volume_attachments?version=2019-07-02","volumeAttachmentTemplate":{"name":"volume attachment","volume":{"id":"volume-id1","name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}}},"Operation":{"Name":"ListVolumeAttachment","Method":"GET","PathPattern":"v1/instances/{instance-id}/volume_attachments"}}
{"level":"info","ts":"2022-02-04T05:57:01.020-0800","caller":"instances/list_volume_attachments.go:48","msg":"Successfuly retrieved the volume attachments"}
{"level":"info","ts":"2022-02-04T05:57:01.020-0800","caller":"metrics/metrics.go:65","msg":"Time to complete","VolumeAttachService.ListVolumeAttachments":0.006556313}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION VolumeAttachService.ListVolumeAttachments IS 6.662941ms
--- PASS: TestListVolumeAttachment (0.02s)
    --- PASS: TestListVolumeAttachment/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestListVolumeAttachment/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestListVolumeAttachment/Verify_that_the_volume_attachment_is_done_correctly (0.01s)
PASS
coverage: 92.2% of statements
ok  	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/instances	0.302s	coverage: 92.2% of statements
=== RUN   TestCheckSnapshotTag
=== RUN   TestCheckSnapshotTag/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.403-0800","caller":"vpcvolume/check_snapshot_tag_test.go:78","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.403-0800","caller":"vpcvolume/check_snapshot_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:32933/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags/%7Btag-name%7D?version=2019-07-02"}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CheckSnapshotTag IS 6.687859ms
=== RUN   TestCheckSnapshotTag/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.413-0800","caller":"vpcvolume/check_snapshot_tag_test.go:78","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.414-0800","caller":"vpcvolume/check_snapshot_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:39709/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags/%7Btag-name%7D?version=2019-07-02"}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CheckSnapshotTag IS 12.064298ms
=== RUN   TestCheckSnapshotTag/Verify_that_the_snapshot_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.427-0800","caller":"vpcvolume/check_snapshot_tag_test.go:78","msg":"Test case being executed","testcase":"Verify that the snapshot is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.427-0800","caller":"vpcvolume/check_snapshot_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:43683/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags/%7Btag-name%7D?version=2019-07-02"}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CheckSnapshotTag IS 5.58675ms
=== RUN   TestCheckSnapshotTag/Verify_that_the_snapshot_tag_exists
{"level":"info","ts":"2022-02-04T05:57:01.433-0800","caller":"vpcvolume/check_snapshot_tag_test.go:78","msg":"Test case being executed","testcase":"Verify that the snapshot tag exists"}
{"level":"info","ts":"2022-02-04T05:57:01.434-0800","caller":"vpcvolume/check_snapshot_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:42083/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags/%7Btag-name%7D?version=2019-07-02"}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CheckSnapshotTag IS 4.136873ms
--- PASS: TestCheckSnapshotTag (0.04s)
    --- PASS: TestCheckSnapshotTag/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestCheckSnapshotTag/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestCheckSnapshotTag/Verify_that_the_snapshot_is_parsed_correctly (0.01s)
    --- PASS: TestCheckSnapshotTag/Verify_that_the_snapshot_tag_exists (0.01s)
=== RUN   TestCheckVolumeTag
=== RUN   TestCheckVolumeTag/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.439-0800","caller":"vpcvolume/check_volume_tag_test.go:79","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.440-0800","caller":"vpcvolume/check_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:45193/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"CheckVolumeTag","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CheckVolumeTag IS 5.970436ms
=== RUN   TestCheckVolumeTag/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.446-0800","caller":"vpcvolume/check_volume_tag_test.go:79","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.446-0800","caller":"vpcvolume/check_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:33689/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"CheckVolumeTag","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CheckVolumeTag IS 5.088878ms
=== RUN   TestCheckVolumeTag/Verify_that_the_volume_is_parsed_correctly_and_has_correct_tag_name
{"level":"info","ts":"2022-02-04T05:57:01.452-0800","caller":"vpcvolume/check_volume_tag_test.go:79","msg":"Test case being executed","testcase":"Verify that the volume is parsed correctly and has correct tag name"}
{"level":"info","ts":"2022-02-04T05:57:01.453-0800","caller":"vpcvolume/check_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:42833/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"CheckVolumeTag","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CheckVolumeTag IS 7.131731ms
=== RUN   TestCheckVolumeTag/False_positive:_What_if_the_volume_ID_is_not_matched
{"level":"info","ts":"2022-02-04T05:57:01.461-0800","caller":"vpcvolume/check_volume_tag_test.go:79","msg":"Test case being executed","testcase":"False positive: What if the volume ID is not matched"}
{"level":"info","ts":"2022-02-04T05:57:01.461-0800","caller":"vpcvolume/check_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:43295/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"CheckVolumeTag","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CheckVolumeTag IS 6.05876ms
=== RUN   TestCheckVolumeTag/False_positive:_What_if_the_tag_name_is_not_matched
{"level":"info","ts":"2022-02-04T05:57:01.469-0800","caller":"vpcvolume/check_volume_tag_test.go:79","msg":"Test case being executed","testcase":"False positive: What if the tag name is not matched"}
{"level":"info","ts":"2022-02-04T05:57:01.469-0800","caller":"vpcvolume/check_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:34995/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"CheckVolumeTag","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CheckVolumeTag IS 13.259675ms
--- PASS: TestCheckVolumeTag (0.04s)
    --- PASS: TestCheckVolumeTag/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestCheckVolumeTag/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestCheckVolumeTag/Verify_that_the_volume_is_parsed_correctly_and_has_correct_tag_name (0.01s)
    --- PASS: TestCheckVolumeTag/False_positive:_What_if_the_volume_ID_is_not_matched (0.01s)
    --- PASS: TestCheckVolumeTag/False_positive:_What_if_the_tag_name_is_not_matched (0.01s)
=== RUN   TestCreateSnapshot
=== RUN   TestCreateSnapshot/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.484-0800","caller":"vpcvolume/create_snapshot_test.go:88","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.484-0800","caller":"vpcvolume/create_snapshot.go:38","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:44271/v1/volumes/%7Bvolume-id%7D/snapshots?version=2019-07-02","Payload":{"id":"snapshot-id","name":"snapshot-name"},"Operation":{"Name":"CreateSnapshot","Method":"POST","PathPattern":"/v1/volumes/{volume-id}/snapshots"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CreateSnapshot IS 5.631721ms
{"level":"info","ts":"2022-02-04T05:57:01.489-0800","caller":"vpcvolume/create_snapshot_test.go:93","msg":"Snapshot","snapshot":null}
=== RUN   TestCreateSnapshot/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.490-0800","caller":"vpcvolume/create_snapshot_test.go:88","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.491-0800","caller":"vpcvolume/create_snapshot.go:38","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:41967/v1/volumes/%7Bvolume-id%7D/snapshots?version=2019-07-02","Payload":{"id":"snapshot-id","name":"snapshot-name"},"Operation":{"Name":"CreateSnapshot","Method":"POST","PathPattern":"/v1/volumes/{volume-id}/snapshots"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CreateSnapshot IS 5.937042ms
{"level":"info","ts":"2022-02-04T05:57:01.497-0800","caller":"vpcvolume/create_snapshot_test.go:93","msg":"Snapshot","snapshot":null}
=== RUN   TestCreateSnapshot/Verify_that_the_snapshot_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.498-0800","caller":"vpcvolume/create_snapshot_test.go:88","msg":"Test case being executed","testcase":"Verify that the snapshot is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.498-0800","caller":"vpcvolume/create_snapshot.go:38","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:37141/v1/volumes/%7Bvolume-id%7D/snapshots?version=2019-07-02","Payload":{"id":"snapshot-id","name":"snapshot-name"},"Operation":{"Name":"CreateSnapshot","Method":"POST","PathPattern":"/v1/volumes/{volume-id}/snapshots"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CreateSnapshot IS 6.310928ms
{"level":"info","ts":"2022-02-04T05:57:01.504-0800","caller":"vpcvolume/create_snapshot_test.go:93","msg":"Snapshot","snapshot":{"id":"snapshot1","status":"pending"}}
=== RUN   TestCreateSnapshot/Verify_that_the_snapshot_is_parsed_correctly#01
{"level":"info","ts":"2022-02-04T05:57:01.505-0800","caller":"vpcvolume/create_snapshot_test.go:88","msg":"Test case being executed","testcase":"Verify that the snapshot is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.505-0800","caller":"vpcvolume/create_snapshot.go:38","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:33691/v1/volumes/%7Bvolume-id%7D/snapshots?version=2019-07-02","Payload":{"id":"snapshot-id","name":"snapshot-name"},"Operation":{"Name":"CreateSnapshot","Method":"POST","PathPattern":"/v1/volumes/{volume-id}/snapshots"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CreateSnapshot IS 6.171956ms
{"level":"info","ts":"2022-02-04T05:57:01.512-0800","caller":"vpcvolume/create_snapshot_test.go:93","msg":"Snapshot","snapshot":{"id":"snapshot1","status":"pending"}}
--- PASS: TestCreateSnapshot (0.03s)
    --- PASS: TestCreateSnapshot/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestCreateSnapshot/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestCreateSnapshot/Verify_that_the_snapshot_is_parsed_correctly (0.01s)
    --- PASS: TestCreateSnapshot/Verify_that_the_snapshot_is_parsed_correctly#01 (0.01s)
=== RUN   TestCreateVolume
=== RUN   TestCreateVolume/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.513-0800","caller":"vpcvolume/create_volume_test.go:94","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.514-0800","caller":"vpcvolume/create_volume.go:38","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:45771/v1/volumes?version=2019-07-02","Payload":{"name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}},"Operation":{"Name":"CreateVolume","Method":"POST","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CreateVolume IS 5.991788ms
{"level":"info","ts":"2022-02-04T05:57:01.520-0800","caller":"vpcvolume/create_volume_test.go:99","msg":"Volume details","volume":{}}
=== RUN   TestCreateVolume/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.521-0800","caller":"vpcvolume/create_volume_test.go:94","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.521-0800","caller":"vpcvolume/create_volume.go:38","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:37595/v1/volumes?version=2019-07-02","Payload":{"name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}},"Operation":{"Name":"CreateVolume","Method":"POST","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CreateVolume IS 5.905011ms
{"level":"info","ts":"2022-02-04T05:57:01.527-0800","caller":"vpcvolume/create_volume_test.go:99","msg":"Volume details","volume":null}
=== RUN   TestCreateVolume/Verify_that_the_volume_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.528-0800","caller":"vpcvolume/create_volume_test.go:94","msg":"Test case being executed","testcase":"Verify that the volume is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.528-0800","caller":"vpcvolume/create_volume.go:38","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:38489/v1/volumes?version=2019-07-02","Payload":{"name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}},"Operation":{"Name":"CreateVolume","Method":"POST","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CreateVolume IS 9.110911ms
{"level":"info","ts":"2022-02-04T05:57:01.539-0800","caller":"vpcvolume/create_volume_test.go:99","msg":"Volume details","volume":{"id":"volume-id","name":"volume-name","capacity":10,"iops":3000,"status":"pending","zone":{"name":"test-1","href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/test-1"},"crn":"crn:v1:bluemix:public:is:test-1:a/rg1::volume:vol1"}}
=== RUN   TestCreateVolume/Verify_that_the_volume_is_parsed_correctly_with_encryption_key
{"level":"info","ts":"2022-02-04T05:57:01.540-0800","caller":"vpcvolume/create_volume_test.go:94","msg":"Test case being executed","testcase":"Verify that the volume is parsed correctly with encryption key"}
{"level":"info","ts":"2022-02-04T05:57:01.540-0800","caller":"vpcvolume/create_volume.go:38","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:35059/v1/volumes?version=2019-07-02","Payload":{"name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}},"Operation":{"Name":"CreateVolume","Method":"POST","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CreateVolume IS 7.955807ms
{"level":"info","ts":"2022-02-04T05:57:01.548-0800","caller":"vpcvolume/create_volume_test.go:99","msg":"Volume details","volume":{"id":"volume-id","name":"volume-name","capacity":10,"iops":3000,"encryption_key":{"crn":"crn:v1:bluemix:public:kms:us-south:a/abcd32a619db2b564b82a816400bcd12:t36097fd-5051-4582-a641-8f51b5334cfa:key:abc05f428-5fb7-4546-958b-0f4e65266d5c"},"status":"pending","zone":{"name":"test-1","href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/test-1"},"crn":"crn:v1:bluemix:public:is:test-1:a/rg1::volume:vol1"}}
=== RUN   TestCreateVolume/False_positive:_What_if_the_volume_ID_is_not_matched
{"level":"info","ts":"2022-02-04T05:57:01.549-0800","caller":"vpcvolume/create_volume_test.go:94","msg":"Test case being executed","testcase":"False positive: What if the volume ID is not matched"}
{"level":"info","ts":"2022-02-04T05:57:01.549-0800","caller":"vpcvolume/create_volume.go:38","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:42053/v1/volumes?version=2019-07-02","Payload":{"name":"volume-name","capacity":10,"resource_group":{"id":"rg1"},"zone":{"name":"test-1"}},"Operation":{"Name":"CreateVolume","Method":"POST","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION CreateVolume IS 6.664105ms
{"level":"info","ts":"2022-02-04T05:57:01.556-0800","caller":"vpcvolume/create_volume_test.go:99","msg":"Volume details","volume":{"id":"wrong-vol","name":"wrong-vol","capacity":10,"iops":3000,"status":"pending","zone":{"name":"test-1","href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/test-1"},"crn":"crn:v1:bluemix:public:is:test-1:a/rg1::volume:wrong-vol"}}
--- PASS: TestCreateVolume (0.04s)
    --- PASS: TestCreateVolume/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestCreateVolume/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestCreateVolume/Verify_that_the_volume_is_parsed_correctly (0.01s)
    --- PASS: TestCreateVolume/Verify_that_the_volume_is_parsed_correctly_with_encryption_key (0.01s)
    --- PASS: TestCreateVolume/False_positive:_What_if_the_volume_ID_is_not_matched (0.01s)
=== RUN   TestDeleteSnapshotTag
=== RUN   TestDeleteSnapshotTag/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.558-0800","caller":"vpcvolume/delete_snapshot_tag_test.go:67","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.558-0800","caller":"vpcvolume/delete_snapshot_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:37479/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"DeleteSnapshotTag","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteSnapshotTag IS 4.081254ms
=== RUN   TestDeleteSnapshotTag/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.563-0800","caller":"vpcvolume/delete_snapshot_tag_test.go:67","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.563-0800","caller":"vpcvolume/delete_snapshot_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:40217/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"DeleteSnapshotTag","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteSnapshotTag IS 4.927611ms
=== RUN   TestDeleteSnapshotTag/Verify_that_the_snapshot_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.569-0800","caller":"vpcvolume/delete_snapshot_tag_test.go:67","msg":"Test case being executed","testcase":"Verify that the snapshot is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.569-0800","caller":"vpcvolume/delete_snapshot_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:38231/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"DeleteSnapshotTag","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteSnapshotTag IS 4.1332ms
--- PASS: TestDeleteSnapshotTag (0.02s)
    --- PASS: TestDeleteSnapshotTag/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestDeleteSnapshotTag/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestDeleteSnapshotTag/Verify_that_the_snapshot_is_parsed_correctly (0.00s)
=== RUN   TestDeleteSnapshot
=== RUN   TestDeleteSnapshot/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.574-0800","caller":"vpcvolume/delete_snapshot_test.go:69","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.574-0800","caller":"vpcvolume/delete_snapshot.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:46837/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D?version=2019-07-02","Operation":{"Name":"DeleteSnapshot","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteSnapshot IS 3.722444ms
=== RUN   TestDeleteSnapshot/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.579-0800","caller":"vpcvolume/delete_snapshot_test.go:69","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.579-0800","caller":"vpcvolume/delete_snapshot.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:41817/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D?version=2019-07-02","Operation":{"Name":"DeleteSnapshot","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteSnapshot IS 5.292889ms
=== RUN   TestDeleteSnapshot/Verify_that_the_snapshot_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.585-0800","caller":"vpcvolume/delete_snapshot_test.go:69","msg":"Test case being executed","testcase":"Verify that the snapshot is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.585-0800","caller":"vpcvolume/delete_snapshot.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:43409/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D?version=2019-07-02","Operation":{"Name":"DeleteSnapshot","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteSnapshot IS 4.269463ms
--- PASS: TestDeleteSnapshot (0.02s)
    --- PASS: TestDeleteSnapshot/Verify_that_the_correct_endpoint_is_invoked (0.00s)
    --- PASS: TestDeleteSnapshot/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestDeleteSnapshot/Verify_that_the_snapshot_is_parsed_correctly (0.01s)
=== RUN   TestDeleteVolumeTag
=== RUN   TestDeleteVolumeTag/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.590-0800","caller":"vpcvolume/delete_volume_tag_test.go:69","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.591-0800","caller":"vpcvolume/delete_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:40863/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"DeleteVolumeTag","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteVolumeTag IS 5.118398ms
=== RUN   TestDeleteVolumeTag/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.596-0800","caller":"vpcvolume/delete_volume_tag_test.go:69","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.597-0800","caller":"vpcvolume/delete_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:40041/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"DeleteVolumeTag","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteVolumeTag IS 5.003021ms
=== RUN   TestDeleteVolumeTag/Verify_that_the_volume_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.602-0800","caller":"vpcvolume/delete_volume_tag_test.go:69","msg":"Test case being executed","testcase":"Verify that the volume is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.603-0800","caller":"vpcvolume/delete_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:32809/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"DeleteVolumeTag","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteVolumeTag IS 5.969199ms
=== RUN   TestDeleteVolumeTag/False_positive:_What_if_the_volume_ID_is_not_matched
{"level":"info","ts":"2022-02-04T05:57:01.610-0800","caller":"vpcvolume/delete_volume_tag_test.go:69","msg":"Test case being executed","testcase":"False positive: What if the volume ID is not matched"}
{"level":"info","ts":"2022-02-04T05:57:01.610-0800","caller":"vpcvolume/delete_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:40739/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"DeleteVolumeTag","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteVolumeTag IS 5.769277ms
=== RUN   TestDeleteVolumeTag/False_positive:_What_if_the_tag_name_is_not_matched
{"level":"info","ts":"2022-02-04T05:57:01.617-0800","caller":"vpcvolume/delete_volume_tag_test.go:69","msg":"Test case being executed","testcase":"False positive: What if the tag name is not matched"}
{"level":"info","ts":"2022-02-04T05:57:01.617-0800","caller":"vpcvolume/delete_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:39247/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"DeleteVolumeTag","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteVolumeTag IS 6.662664ms
--- PASS: TestDeleteVolumeTag (0.03s)
    --- PASS: TestDeleteVolumeTag/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestDeleteVolumeTag/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestDeleteVolumeTag/Verify_that_the_volume_is_parsed_correctly (0.01s)
    --- PASS: TestDeleteVolumeTag/False_positive:_What_if_the_volume_ID_is_not_matched (0.01s)
    --- PASS: TestDeleteVolumeTag/False_positive:_What_if_the_tag_name_is_not_matched (0.01s)
=== RUN   TestDeleteVolume
=== RUN   TestDeleteVolume/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.625-0800","caller":"vpcvolume/delete_volume_test.go:65","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.625-0800","caller":"vpcvolume/delete_volume.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:45839/v1/volumes/%7Bvolume-id%7D?version=2019-07-02","Operation":{"Name":"DeleteVolume","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteVolume IS 5.043496ms
=== RUN   TestDeleteVolume/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.631-0800","caller":"vpcvolume/delete_volume_test.go:65","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.631-0800","caller":"vpcvolume/delete_volume.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:34343/v1/volumes/%7Bvolume-id%7D?version=2019-07-02","Operation":{"Name":"DeleteVolume","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteVolume IS 4.084813ms
=== RUN   TestDeleteVolume/Verify_that_the_volume_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.636-0800","caller":"vpcvolume/delete_volume_test.go:65","msg":"Test case being executed","testcase":"Verify that the volume is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.636-0800","caller":"vpcvolume/delete_volume.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:44661/v1/volumes/%7Bvolume-id%7D?version=2019-07-02","Operation":{"Name":"DeleteVolume","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteVolume IS 5.234435ms
=== RUN   TestDeleteVolume/False_positive:_What_if_the_volume_ID_is_not_matched
{"level":"info","ts":"2022-02-04T05:57:01.643-0800","caller":"vpcvolume/delete_volume_test.go:65","msg":"Test case being executed","testcase":"False positive: What if the volume ID is not matched"}
{"level":"info","ts":"2022-02-04T05:57:01.643-0800","caller":"vpcvolume/delete_volume.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:39883/v1/volumes/%7Bvolume-id%7D?version=2019-07-02","Operation":{"Name":"DeleteVolume","Method":"DELETE","PathPattern":"/v1/volumes/{volume-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION DeleteVolume IS 7.443909ms
--- PASS: TestDeleteVolume (0.03s)
    --- PASS: TestDeleteVolume/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestDeleteVolume/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestDeleteVolume/Verify_that_the_volume_is_parsed_correctly (0.01s)
    --- PASS: TestDeleteVolume/False_positive:_What_if_the_volume_ID_is_not_matched (0.01s)
=== RUN   TestExpandVolume
=== RUN   TestExpandVolume/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.651-0800","caller":"vpcvolume/expand_volume_test.go:77","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.651-0800","caller":"vpcvolume/expand_volume.go:39","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:40525/v1/volumes/volume-id?version=2019-07-02","Payload":{"capacity":300},"Operation":{"Name":"ExpandVolume","Method":"PATCH","PathPattern":"/v1/volumes/{volume-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ExpandVolume IS 4.567876ms
{"level":"info","ts":"2022-02-04T05:57:01.656-0800","caller":"vpcvolume/expand_volume_test.go:82","msg":"Volume details","volume":{}}
=== RUN   TestExpandVolume/Verify_that_the_volume_expended_correctly
{"level":"info","ts":"2022-02-04T05:57:01.658-0800","caller":"vpcvolume/expand_volume_test.go:77","msg":"Test case being executed","testcase":"Verify that the volume expended correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.658-0800","caller":"vpcvolume/expand_volume.go:39","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:33367/v1/volumes/volume-id?version=2019-07-02","Payload":{"capacity":300},"Operation":{"Name":"ExpandVolume","Method":"PATCH","PathPattern":"/v1/volumes/{volume-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ExpandVolume IS 7.856563ms
{"level":"info","ts":"2022-02-04T05:57:01.666-0800","caller":"vpcvolume/expand_volume_test.go:82","msg":"Volume details","volume":{"id":"volume-id","name":"volume-name","capacity":300,"iops":3000,"status":"pending","zone":{"name":"test-1","href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/test-1"},"crn":"crn:v1:bluemix:public:is:test-1:a/rg1::volume:vol1"}}
=== RUN   TestExpandVolume/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.667-0800","caller":"vpcvolume/expand_volume_test.go:77","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.667-0800","caller":"vpcvolume/expand_volume.go:39","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:41193/v1/volumes/volume-id?version=2019-07-02","Payload":{"capacity":300},"Operation":{"Name":"ExpandVolume","Method":"PATCH","PathPattern":"/v1/volumes/{volume-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ExpandVolume IS 4.802342ms
{"level":"info","ts":"2022-02-04T05:57:01.672-0800","caller":"vpcvolume/expand_volume_test.go:82","msg":"Volume details","volume":null}
=== RUN   TestExpandVolume/False_positive:_What_if_the_volume_ID_is_not_matched
{"level":"info","ts":"2022-02-04T05:57:01.673-0800","caller":"vpcvolume/expand_volume_test.go:77","msg":"Test case being executed","testcase":"False positive: What if the volume ID is not matched"}
{"level":"info","ts":"2022-02-04T05:57:01.673-0800","caller":"vpcvolume/expand_volume.go:39","msg":"Equivalent curl command and payload details","URL":"http://127.0.0.1:45943/v1/volumes/volume-id?version=2019-07-02","Payload":{"capacity":300},"Operation":{"Name":"ExpandVolume","Method":"PATCH","PathPattern":"/v1/volumes/{volume-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ExpandVolume IS 7.522174ms
{"level":"info","ts":"2022-02-04T05:57:01.681-0800","caller":"vpcvolume/expand_volume_test.go:82","msg":"Volume details","volume":{"id":"wrong-vol","name":"wrong-vol","capacity":10,"iops":3000,"tags":["Wrong Tag"],"status":"pending","zone":{"name":"test-1","href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/test-1"},"crn":"crn:v1:bluemix:public:is:test-1:a/rg1::volume:wrong-vol"}}
--- PASS: TestExpandVolume (0.03s)
    --- PASS: TestExpandVolume/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestExpandVolume/Verify_that_the_volume_expended_correctly (0.01s)
    --- PASS: TestExpandVolume/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestExpandVolume/False_positive:_What_if_the_volume_ID_is_not_matched (0.01s)
=== RUN   TestGetSnapshot
=== RUN   TestGetSnapshot/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.682-0800","caller":"vpcvolume/get_snapshot_test.go:72","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.683-0800","caller":"vpcvolume/get_snapshot.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:44917/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D?version=2019-07-02","Operation":{"Name":"GetSnapshot","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION GetSnapshot IS 4.519706ms
{"level":"info","ts":"2022-02-04T05:57:01.687-0800","caller":"vpcvolume/get_snapshot_test.go:76","msg":"Snapshot details","snapshot":{}}
=== RUN   TestGetSnapshot/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.688-0800","caller":"vpcvolume/get_snapshot_test.go:72","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.689-0800","caller":"vpcvolume/get_snapshot.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:45937/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D?version=2019-07-02","Operation":{"Name":"GetSnapshot","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION GetSnapshot IS 5.713629ms
{"level":"info","ts":"2022-02-04T05:57:01.694-0800","caller":"vpcvolume/get_snapshot_test.go:76","msg":"Snapshot details","snapshot":null}
=== RUN   TestGetSnapshot/Verify_that_the_snapshot_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.695-0800","caller":"vpcvolume/get_snapshot_test.go:72","msg":"Test case being executed","testcase":"Verify that the snapshot is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.695-0800","caller":"vpcvolume/get_snapshot.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:37923/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D?version=2019-07-02","Operation":{"Name":"GetSnapshot","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION GetSnapshot IS 4.715319ms
{"level":"info","ts":"2022-02-04T05:57:01.700-0800","caller":"vpcvolume/get_snapshot_test.go:76","msg":"Snapshot details","snapshot":{"id":"snapshot1","name":"snapshot1","status":"pending"}}
--- PASS: TestGetSnapshot (0.02s)
    --- PASS: TestGetSnapshot/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestGetSnapshot/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestGetSnapshot/Verify_that_the_snapshot_is_parsed_correctly (0.01s)
=== RUN   TestGetVolume
=== RUN   TestGetVolume/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.701-0800","caller":"vpcvolume/get_volume_test.go:98","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.702-0800","caller":"vpcvolume/get_volume.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:46857/v1/volumes/%7Bvolume-id%7D?version=2019-07-02","Operation":{"Name":"GetVolume","Method":"GET","PathPattern":"/v1/volumes/{volume-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION GetVolume IS 4.714582ms
{"level":"info","ts":"2022-02-04T05:57:01.706-0800","caller":"vpcvolume/get_volume_test.go:103","msg":"Volume details","volume":{}}
=== RUN   TestGetVolume/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.707-0800","caller":"vpcvolume/get_volume_test.go:98","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.708-0800","caller":"vpcvolume/get_volume.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:46791/v1/volumes/%7Bvolume-id%7D?version=2019-07-02","Operation":{"Name":"GetVolume","Method":"GET","PathPattern":"/v1/volumes/{volume-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION GetVolume IS 4.113029ms
{"level":"info","ts":"2022-02-04T05:57:01.712-0800","caller":"vpcvolume/get_volume_test.go:103","msg":"Volume details","volume":null}
=== RUN   TestGetVolume/Verify_that_the_volume_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.712-0800","caller":"vpcvolume/get_volume_test.go:98","msg":"Test case being executed","testcase":"Verify that the volume is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.713-0800","caller":"vpcvolume/get_volume.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:41825/v1/volumes/%7Bvolume-id%7D?version=2019-07-02","Operation":{"Name":"GetVolume","Method":"GET","PathPattern":"/v1/volumes/{volume-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION GetVolume IS 4.956008ms
{"level":"info","ts":"2022-02-04T05:57:01.718-0800","caller":"vpcvolume/get_volume_test.go:103","msg":"Volume details","volume":{"id":"vol1","name":"vol1","capacity":10,"iops":3000,"status":"pending","zone":{"name":"test-1","href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/test-1"},"crn":"crn:v1:bluemix:public:is:test-1:a/rg1::volume:vol1"}}
=== RUN   TestGetVolume/False_positive:_What_if_the_volume_ID_is_not_matched
{"level":"info","ts":"2022-02-04T05:57:01.720-0800","caller":"vpcvolume/get_volume_test.go:98","msg":"Test case being executed","testcase":"False positive: What if the volume ID is not matched"}
{"level":"info","ts":"2022-02-04T05:57:01.720-0800","caller":"vpcvolume/get_volume.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:40359/v1/volumes/%7Bvolume-id%7D?version=2019-07-02","Operation":{"Name":"GetVolume","Method":"GET","PathPattern":"/v1/volumes/{volume-id}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION GetVolume IS 5.956577ms
{"level":"info","ts":"2022-02-04T05:57:01.726-0800","caller":"vpcvolume/get_volume_test.go:103","msg":"Volume details","volume":{"id":"wrong-vol","name":"wrong-vol","capacity":10,"iops":3000,"status":"pending","zone":{"name":"test-1","href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/test-1"},"crn":"crn:v1:bluemix:public:is:test-1:a/rg1::volume:wrong-vol"}}
--- PASS: TestGetVolume (0.03s)
    --- PASS: TestGetVolume/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestGetVolume/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestGetVolume/Verify_that_the_volume_is_parsed_correctly (0.01s)
    --- PASS: TestGetVolume/False_positive:_What_if_the_volume_ID_is_not_matched (0.01s)
=== RUN   TestGetVolumeByName
=== RUN   TestGetVolumeByName/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.727-0800","caller":"vpcvolume/get_volume_test.go:170","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.728-0800","caller":"vpcvolume/list_volumes.go:39","msg":"Equivalent curl command","URL":"http://127.0.0.1:44059/v1/volumes?version=2019-07-02","Operation":{"Name":"ListVolumes","Method":"GET","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumes IS 3.536742ms
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION GetVolumeByName IS 3.590348ms
{"level":"info","ts":"2022-02-04T05:57:01.731-0800","caller":"vpcvolume/get_volume_test.go:174","msg":"Volume details","volume":null}
=== RUN   TestGetVolumeByName/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.732-0800","caller":"vpcvolume/get_volume_test.go:170","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.732-0800","caller":"vpcvolume/list_volumes.go:39","msg":"Equivalent curl command","URL":"http://127.0.0.1:39633/v1/volumes?version=2019-07-02","Operation":{"Name":"ListVolumes","Method":"GET","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumes IS 4.222805ms
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION GetVolumeByName IS 4.275742ms
{"level":"info","ts":"2022-02-04T05:57:01.737-0800","caller":"vpcvolume/get_volume_test.go:174","msg":"Volume details","volume":null}
=== RUN   TestGetVolumeByName/Verify_that_the_volume_name_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.738-0800","caller":"vpcvolume/get_volume_test.go:170","msg":"Test case being executed","testcase":"Verify that the volume name is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.738-0800","caller":"vpcvolume/list_volumes.go:39","msg":"Equivalent curl command","URL":"http://127.0.0.1:39731/v1/volumes?version=2019-07-02","Operation":{"Name":"ListVolumes","Method":"GET","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumes IS 5.279678ms
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION GetVolumeByName IS 5.32761ms
{"level":"info","ts":"2022-02-04T05:57:01.743-0800","caller":"vpcvolume/get_volume_test.go:174","msg":"Volume details","volume":{"id":"vol1","name":"vol1","capacity":10,"iops":3000,"status":"pending","zone":{"name":"test-1","href":"https://us-south.iaas.cloud.ibm.com/v1/regions/us-south/zones/test-1"},"crn":"crn:v1:bluemix:public:is:test-1:a/rg1::volume:vol1"}}
=== RUN   TestGetVolumeByName/Verify_that_the_volume_is_empty_if_the_volumes_are_empty
{"level":"info","ts":"2022-02-04T05:57:01.744-0800","caller":"vpcvolume/get_volume_test.go:170","msg":"Test case being executed","testcase":"Verify that the volume is empty if the volumes are empty"}
{"level":"info","ts":"2022-02-04T05:57:01.744-0800","caller":"vpcvolume/list_volumes.go:39","msg":"Equivalent curl command","URL":"http://127.0.0.1:37345/v1/volumes?version=2019-07-02","Operation":{"Name":"ListVolumes","Method":"GET","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumes IS 4.563225ms
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION GetVolumeByName IS 4.612765ms
{"level":"info","ts":"2022-02-04T05:57:01.749-0800","caller":"vpcvolume/get_volume_test.go:174","msg":"Volume details","volume":null}
--- PASS: TestGetVolumeByName (0.02s)
    --- PASS: TestGetVolumeByName/Verify_that_the_correct_endpoint_is_invoked (0.00s)
    --- PASS: TestGetVolumeByName/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestGetVolumeByName/Verify_that_the_volume_name_is_parsed_correctly (0.01s)
    --- PASS: TestGetVolumeByName/Verify_that_the_volume_is_empty_if_the_volumes_are_empty (0.01s)
=== RUN   TestUpdateVolume
=== RUN   TestUpdateVolume/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.750-0800","caller":"vpcvolume/iks_update_volume_test.go:67","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.750-0800","caller":"vpcvolume/iks_update_volume.go:35","msg":"Equivalent curl command","URL":"http://127.0.0.1:33067/v2/storage/updateVolume?version=2019-07-02","Operation":{"Name":"UpdateVolume","Method":"POST","PathPattern":"v2/storage/updateVolume"},"volumeTemplate":{}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION IKSVolumeService.UpdateVolume IS 4.045875ms
=== RUN   TestUpdateVolume/Verify_that_the_volume_is_updated_succesfully
{"level":"info","ts":"2022-02-04T05:57:01.755-0800","caller":"vpcvolume/iks_update_volume_test.go:67","msg":"Test case being executed","testcase":"Verify that the volume is updated succesfully"}
{"level":"info","ts":"2022-02-04T05:57:01.755-0800","caller":"vpcvolume/iks_update_volume.go:35","msg":"Equivalent curl command","URL":"http://127.0.0.1:45659/v2/storage/updateVolume?version=2019-07-02","Operation":{"Name":"UpdateVolume","Method":"POST","PathPattern":"v2/storage/updateVolume"},"volumeTemplate":{"id":"volume-id","capacity":2,"iops":300,"tags":["tag1:val1","tag2:val2"],"crn":"crn:v1:staging:public:is:us-south-1:a/account-id::volume:volume-id","cluster":"cluster-id","provider":"vpc-classic","volume_type":"block"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION IKSVolumeService.UpdateVolume IS 5.976822ms
--- PASS: TestUpdateVolume (0.01s)
    --- PASS: TestUpdateVolume/Verify_that_the_correct_endpoint_is_invoked (0.00s)
    --- PASS: TestUpdateVolume/Verify_that_the_volume_is_updated_succesfully (0.01s)
=== RUN   TestListSnapshotTags
=== RUN   TestListSnapshotTags/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.762-0800","caller":"vpcvolume/list_snapshot_tags_test.go:72","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.762-0800","caller":"vpcvolume/list_snapshot_tags.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:35887/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags?version=2019-07-02","Operation":{"Name":"ListSnapshotTags","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}/tags"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListSnapshotTags IS 3.84985ms
{"level":"info","ts":"2022-02-04T05:57:01.766-0800","caller":"vpcvolume/list_snapshot_tags_test.go:77","msg":"Tags","tags":null}
=== RUN   TestListSnapshotTags/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.767-0800","caller":"vpcvolume/list_snapshot_tags_test.go:72","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.767-0800","caller":"vpcvolume/list_snapshot_tags.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:45795/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags?version=2019-07-02","Operation":{"Name":"ListSnapshotTags","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}/tags"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListSnapshotTags IS 4.955132ms
{"level":"info","ts":"2022-02-04T05:57:01.772-0800","caller":"vpcvolume/list_snapshot_tags_test.go:77","msg":"Tags","tags":null}
=== RUN   TestListSnapshotTags/Verify_that_the_snapshot_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.773-0800","caller":"vpcvolume/list_snapshot_tags_test.go:72","msg":"Test case being executed","testcase":"Verify that the snapshot is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.774-0800","caller":"vpcvolume/list_snapshot_tags.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:33253/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags?version=2019-07-02","Operation":{"Name":"ListSnapshotTags","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}/tags"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListSnapshotTags IS 6.093236ms
{"level":"info","ts":"2022-02-04T05:57:01.780-0800","caller":"vpcvolume/list_snapshot_tags_test.go:77","msg":"Tags","tags":["tag1"]}
--- PASS: TestListSnapshotTags (0.02s)
    --- PASS: TestListSnapshotTags/Verify_that_the_correct_endpoint_is_invoked (0.00s)
    --- PASS: TestListSnapshotTags/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestListSnapshotTags/Verify_that_the_snapshot_is_parsed_correctly (0.01s)
=== RUN   TestListSnapshots
=== RUN   TestListSnapshots/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.781-0800","caller":"vpcvolume/list_snapshots_test.go:71","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.781-0800","caller":"vpcvolume/list_snapshots.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:37901/v1/volumes/%7Bvolume-id%7D/snapshots?version=2019-07-02","Operation":{"Name":"ListSnapshots","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/snapshots"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListSnapshots IS 5.174904ms
{"level":"info","ts":"2022-02-04T05:57:01.786-0800","caller":"vpcvolume/list_snapshots_test.go:76","msg":"Snapshots","snapshots":{}}
=== RUN   TestListSnapshots/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.787-0800","caller":"vpcvolume/list_snapshots_test.go:71","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.787-0800","caller":"vpcvolume/list_snapshots.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:43779/v1/volumes/%7Bvolume-id%7D/snapshots?version=2019-07-02","Operation":{"Name":"ListSnapshots","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/snapshots"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListSnapshots IS 5.433827ms
{"level":"info","ts":"2022-02-04T05:57:01.793-0800","caller":"vpcvolume/list_snapshots_test.go:76","msg":"Snapshots","snapshots":null}
=== RUN   TestListSnapshots/Verify_that_the_snapshot_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.794-0800","caller":"vpcvolume/list_snapshots_test.go:71","msg":"Test case being executed","testcase":"Verify that the snapshot is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.794-0800","caller":"vpcvolume/list_snapshots.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:32913/v1/volumes/%7Bvolume-id%7D/snapshots?version=2019-07-02","Operation":{"Name":"ListSnapshots","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/snapshots"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListSnapshots IS 4.171976ms
{"level":"info","ts":"2022-02-04T05:57:01.798-0800","caller":"vpcvolume/list_snapshots_test.go:76","msg":"Snapshots","snapshots":{}}
--- PASS: TestListSnapshots (0.02s)
    --- PASS: TestListSnapshots/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestListSnapshots/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestListSnapshots/Verify_that_the_snapshot_is_parsed_correctly (0.01s)
=== RUN   TestListVolumeTags
=== RUN   TestListVolumeTags/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.799-0800","caller":"vpcvolume/list_volume_tags_test.go:57","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.800-0800","caller":"vpcvolume/list_volume_tags.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:33247/v1/volumes/%7Bvolume-id%7D/tags?version=2019-07-02","Operation":{"Name":"ListVolumeTags","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/tags"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumeTags IS 3.546877ms
{"level":"info","ts":"2022-02-04T05:57:01.803-0800","caller":"vpcvolume/list_volume_tags_test.go:62","msg":"volumeTags","volumeTags":null}
=== RUN   TestListVolumeTags/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.804-0800","caller":"vpcvolume/list_volume_tags_test.go:57","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.804-0800","caller":"vpcvolume/list_volume_tags.go:38","msg":"Equivalent curl command","URL":"http://127.0.0.1:42913/v1/volumes/%7Bvolume-id%7D/tags?version=2019-07-02","Operation":{"Name":"ListVolumeTags","Method":"GET","PathPattern":"/v1/volumes/{volume-id}/tags"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumeTags IS 5.224322ms
{"level":"info","ts":"2022-02-04T05:57:01.809-0800","caller":"vpcvolume/list_volume_tags_test.go:62","msg":"volumeTags","volumeTags":null}
--- PASS: TestListVolumeTags (0.01s)
    --- PASS: TestListVolumeTags/Verify_that_the_correct_endpoint_is_invoked (0.00s)
    --- PASS: TestListVolumeTags/Verify_that_a_404_is_returned_to_the_caller (0.01s)
=== RUN   TestListVolumes
=== RUN   TestListVolumes/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.811-0800","caller":"vpcvolume/list_volumes_test.go:125","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.811-0800","caller":"vpcvolume/list_volumes.go:39","msg":"Equivalent curl command","URL":"http://127.0.0.1:39047/v1/volumes?version=2019-07-02","Operation":{"Name":"ListVolumes","Method":"GET","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumes IS 3.812997ms
{"level":"info","ts":"2022-02-04T05:57:01.815-0800","caller":"vpcvolume/list_volumes_test.go:130","msg":"Volumes","volumes":{"volumes":null}}
=== RUN   TestListVolumes/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.816-0800","caller":"vpcvolume/list_volumes_test.go:125","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.816-0800","caller":"vpcvolume/list_volumes.go:39","msg":"Equivalent curl command","URL":"http://127.0.0.1:40895/v1/volumes?version=2019-07-02","Operation":{"Name":"ListVolumes","Method":"GET","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumes IS 11.403716ms
{"level":"info","ts":"2022-02-04T05:57:01.828-0800","caller":"vpcvolume/list_volumes_test.go:130","msg":"Volumes","volumes":null}
=== RUN   TestListVolumes/Verify_that_limit_is_added_to_the_query
{"level":"info","ts":"2022-02-04T05:57:01.829-0800","caller":"vpcvolume/list_volumes_test.go:125","msg":"Test case being executed","testcase":"Verify that limit is added to the query"}
{"level":"info","ts":"2022-02-04T05:57:01.829-0800","caller":"vpcvolume/list_volumes.go:39","msg":"Equivalent curl command","URL":"http://127.0.0.1:33149/v1/volumes?version=2019-07-02","Operation":{"Name":"ListVolumes","Method":"GET","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumes IS 20.956293ms
{"level":"info","ts":"2022-02-04T05:57:01.850-0800","caller":"vpcvolume/list_volumes_test.go:130","msg":"Volumes","volumes":{"volumes":null}}
=== RUN   TestListVolumes/Verify_that_start_is_added_to_the_query
{"level":"info","ts":"2022-02-04T05:57:01.851-0800","caller":"vpcvolume/list_volumes_test.go:125","msg":"Test case being executed","testcase":"Verify that start is added to the query"}
{"level":"info","ts":"2022-02-04T05:57:01.851-0800","caller":"vpcvolume/list_volumes.go:39","msg":"Equivalent curl command","URL":"http://127.0.0.1:38755/v1/volumes?version=2019-07-02","Operation":{"Name":"ListVolumes","Method":"GET","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumes IS 19.664104ms
{"level":"info","ts":"2022-02-04T05:57:01.871-0800","caller":"vpcvolume/list_volumes_test.go:130","msg":"Volumes","volumes":{"volumes":null}}
=== RUN   TestListVolumes/Verify_that_resource_group.id_is_added_to_the_query
{"level":"info","ts":"2022-02-04T05:57:01.872-0800","caller":"vpcvolume/list_volumes_test.go:125","msg":"Test case being executed","testcase":"Verify that resource_group.id is added to the query"}
{"level":"info","ts":"2022-02-04T05:57:01.872-0800","caller":"vpcvolume/list_volumes.go:39","msg":"Equivalent curl command","URL":"http://127.0.0.1:43503/v1/volumes?version=2019-07-02","Operation":{"Name":"ListVolumes","Method":"GET","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumes IS 8.880527ms
{"level":"info","ts":"2022-02-04T05:57:01.881-0800","caller":"vpcvolume/list_volumes_test.go:130","msg":"Volumes","volumes":{"volumes":null}}
=== RUN   TestListVolumes/Verify_that_tag_is_added_to_the_query
{"level":"info","ts":"2022-02-04T05:57:01.882-0800","caller":"vpcvolume/list_volumes_test.go:125","msg":"Test case being executed","testcase":"Verify that tag is added to the query"}
{"level":"info","ts":"2022-02-04T05:57:01.882-0800","caller":"vpcvolume/list_volumes.go:39","msg":"Equivalent curl command","URL":"http://127.0.0.1:46213/v1/volumes?version=2019-07-02","Operation":{"Name":"ListVolumes","Method":"GET","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumes IS 3.216414ms
{"level":"info","ts":"2022-02-04T05:57:01.885-0800","caller":"vpcvolume/list_volumes_test.go:130","msg":"Volumes","volumes":{"volumes":null}}
=== RUN   TestListVolumes/Verify_that_zone.name_is_added_to_the_query
{"level":"info","ts":"2022-02-04T05:57:01.886-0800","caller":"vpcvolume/list_volumes_test.go:125","msg":"Test case being executed","testcase":"Verify that zone.name is added to the query"}
{"level":"info","ts":"2022-02-04T05:57:01.886-0800","caller":"vpcvolume/list_volumes.go:39","msg":"Equivalent curl command","URL":"http://127.0.0.1:35789/v1/volumes?version=2019-07-02","Operation":{"Name":"ListVolumes","Method":"GET","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumes IS 3.195313ms
{"level":"info","ts":"2022-02-04T05:57:01.889-0800","caller":"vpcvolume/list_volumes_test.go:130","msg":"Volumes","volumes":{"volumes":null}}
=== RUN   TestListVolumes/Verify_that_volume_name_is_added_to_the_query
{"level":"info","ts":"2022-02-04T05:57:01.891-0800","caller":"vpcvolume/list_volumes_test.go:125","msg":"Test case being executed","testcase":"Verify that volume name is added to the query"}
{"level":"info","ts":"2022-02-04T05:57:01.891-0800","caller":"vpcvolume/list_volumes.go:39","msg":"Equivalent curl command","URL":"http://127.0.0.1:43293/v1/volumes?version=2019-07-02","Operation":{"Name":"ListVolumes","Method":"GET","PathPattern":"/v1/volumes"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION ListVolumes IS 4.40594ms
{"level":"info","ts":"2022-02-04T05:57:01.895-0800","caller":"vpcvolume/list_volumes_test.go:130","msg":"Volumes","volumes":{"volumes":null}}
--- PASS: TestListVolumes (0.09s)
    --- PASS: TestListVolumes/Verify_that_the_correct_endpoint_is_invoked (0.00s)
    --- PASS: TestListVolumes/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestListVolumes/Verify_that_limit_is_added_to_the_query (0.02s)
    --- PASS: TestListVolumes/Verify_that_start_is_added_to_the_query (0.02s)
    --- PASS: TestListVolumes/Verify_that_resource_group.id_is_added_to_the_query (0.01s)
    --- PASS: TestListVolumes/Verify_that_tag_is_added_to_the_query (0.00s)
    --- PASS: TestListVolumes/Verify_that_zone.name_is_added_to_the_query (0.00s)
    --- PASS: TestListVolumes/Verify_that_volume_name_is_added_to_the_query (0.01s)
=== RUN   TestSetSnapshotTag
=== RUN   TestSetSnapshotTag/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.897-0800","caller":"vpcvolume/set_snapshot_tag_test.go:69","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.897-0800","caller":"vpcvolume/set_snapshot_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:44609/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"SetSnapshotTag","Method":"PUT","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION SetSnapshotTag IS 4.37342ms
=== RUN   TestSetSnapshotTag/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.902-0800","caller":"vpcvolume/set_snapshot_tag_test.go:69","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.902-0800","caller":"vpcvolume/set_snapshot_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:40973/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"SetSnapshotTag","Method":"PUT","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION SetSnapshotTag IS 4.487629ms
=== RUN   TestSetSnapshotTag/Verify_that_the_snapshot_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.907-0800","caller":"vpcvolume/set_snapshot_tag_test.go:69","msg":"Test case being executed","testcase":"Verify that the snapshot is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.907-0800","caller":"vpcvolume/set_snapshot_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:46767/v1/volumes/%7Bvolume-id%7D/snapshots/%7Bsnapshot-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"SetSnapshotTag","Method":"PUT","PathPattern":"/v1/volumes/{volume-id}/snapshots/{snapshot-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION SetSnapshotTag IS 4.739372ms
--- PASS: TestSetSnapshotTag (0.02s)
    --- PASS: TestSetSnapshotTag/Verify_that_the_correct_endpoint_is_invoked (0.01s)
    --- PASS: TestSetSnapshotTag/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestSetSnapshotTag/Verify_that_the_snapshot_is_parsed_correctly (0.01s)
=== RUN   TestSetVolumeTag
=== RUN   TestSetVolumeTag/Verify_that_the_correct_endpoint_is_invoked
{"level":"info","ts":"2022-02-04T05:57:01.913-0800","caller":"vpcvolume/set_volume_tag_test.go:82","msg":"Test case being executed","testcase":"Verify that the correct endpoint is invoked"}
{"level":"info","ts":"2022-02-04T05:57:01.913-0800","caller":"vpcvolume/set_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:40561/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"SetVolumeTag","Method":"PUT","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION SetVolumeTag IS 4.049064ms
=== RUN   TestSetVolumeTag/Verify_that_a_404_is_returned_to_the_caller
{"level":"info","ts":"2022-02-04T05:57:01.918-0800","caller":"vpcvolume/set_volume_tag_test.go:82","msg":"Test case being executed","testcase":"Verify that a 404 is returned to the caller"}
{"level":"info","ts":"2022-02-04T05:57:01.918-0800","caller":"vpcvolume/set_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:34557/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"SetVolumeTag","Method":"PUT","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION SetVolumeTag IS 5.341175ms
=== RUN   TestSetVolumeTag/Verify_that_the_volume_is_parsed_correctly
{"level":"info","ts":"2022-02-04T05:57:01.925-0800","caller":"vpcvolume/set_volume_tag_test.go:82","msg":"Test case being executed","testcase":"Verify that the volume is parsed correctly"}
{"level":"info","ts":"2022-02-04T05:57:01.925-0800","caller":"vpcvolume/set_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:37711/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"SetVolumeTag","Method":"PUT","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION SetVolumeTag IS 6.936295ms
=== RUN   TestSetVolumeTag/False_positive:_What_if_the_volume_ID_is_not_matched
{"level":"info","ts":"2022-02-04T05:57:01.933-0800","caller":"vpcvolume/set_volume_tag_test.go:82","msg":"Test case being executed","testcase":"False positive: What if the volume ID is not matched"}
{"level":"info","ts":"2022-02-04T05:57:01.933-0800","caller":"vpcvolume/set_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:33069/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"SetVolumeTag","Method":"PUT","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION SetVolumeTag IS 5.789426ms
=== RUN   TestSetVolumeTag/False_positive:_What_if_the_tag_name_is_not_matched
{"level":"info","ts":"2022-02-04T05:57:01.940-0800","caller":"vpcvolume/set_volume_tag_test.go:82","msg":"Test case being executed","testcase":"False positive: What if the tag name is not matched"}
{"level":"info","ts":"2022-02-04T05:57:01.940-0800","caller":"vpcvolume/set_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:39781/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"SetVolumeTag","Method":"PUT","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION SetVolumeTag IS 5.638346ms
=== RUN   TestSetVolumeTag/False_positive:_What_if_the_tag_name_is_already_set
{"level":"info","ts":"2022-02-04T05:57:01.946-0800","caller":"vpcvolume/set_volume_tag_test.go:82","msg":"Test case being executed","testcase":"False positive: What if the tag name is already set"}
{"level":"info","ts":"2022-02-04T05:57:01.947-0800","caller":"vpcvolume/set_volume_tag.go:37","msg":"Equivalent curl command","URL":"http://127.0.0.1:37615/v1/volumes/%7Bvolume-id%7D/tags/%7Btag-name%7D?version=2019-07-02","Operation":{"Name":"SetVolumeTag","Method":"PUT","PathPattern":"/v1/volumes/{volume-id}/tags/{tag-name}"}}
2022/02/04 05:57:01 TIME TAKEN BY FUNCTION SetVolumeTag IS 5.567478ms
--- PASS: TestSetVolumeTag (0.04s)
    --- PASS: TestSetVolumeTag/Verify_that_the_correct_endpoint_is_invoked (0.00s)
    --- PASS: TestSetVolumeTag/Verify_that_a_404_is_returned_to_the_caller (0.01s)
    --- PASS: TestSetVolumeTag/Verify_that_the_volume_is_parsed_correctly (0.01s)
    --- PASS: TestSetVolumeTag/False_positive:_What_if_the_volume_ID_is_not_matched (0.01s)
    --- PASS: TestSetVolumeTag/False_positive:_What_if_the_tag_name_is_not_matched (0.01s)
    --- PASS: TestSetVolumeTag/False_positive:_What_if_the_tag_name_is_already_set (0.01s)
PASS
coverage: 98.4% of statements
ok  	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/vpcclient/vpcvolume	0.662s	coverage: 98.4% of statements
?   	github.com/IBM/ibmcloud-storage-volume-lib/provider/utils	[no test files]



=== RUN   TestAttachVolume
=== RUN   TestAttachVolume/Instance_ID_is_nil
=== RUN   TestAttachVolume/Volume_ID_is_nil
--- PASS: TestAttachVolume (0.00s)
    --- PASS: TestAttachVolume/Instance_ID_is_nil (0.00s)
    --- PASS: TestAttachVolume/Volume_ID_is_nil (0.00s)
=== RUN   TestAuthorizeVolume
=== RUN   TestAuthorizeVolume/Not_supported
--- PASS: TestAuthorizeVolume (0.00s)
    --- PASS: TestAuthorizeVolume/Not_supported (0.00s)
=== RUN   TestCreateSnapshot
=== RUN   TestCreateSnapshot/Not_supported_yet
=== RUN   TestCreateSnapshot/Not_supported_yet#01
=== RUN   TestCreateSnapshot/Volume_is_nil
=== RUN   TestCreateSnapshot/Volume_is_not_valid
=== RUN   TestCreateSnapshot/Snapshot_creation_failed
=== RUN   TestCreateSnapshot/Create_snapshot
--- PASS: TestCreateSnapshot (80.08s)
    --- PASS: TestCreateSnapshot/Not_supported_yet (0.00s)
    --- PASS: TestCreateSnapshot/Not_supported_yet#01 (40.04s)
    --- PASS: TestCreateSnapshot/Volume_is_nil (0.00s)
    --- PASS: TestCreateSnapshot/Volume_is_not_valid (0.00s)
    --- PASS: TestCreateSnapshot/Snapshot_creation_failed (40.03s)
    --- PASS: TestCreateSnapshot/Create_snapshot (0.00s)
=== RUN   TestCreateSnapshotTwo
--- PASS: TestCreateSnapshotTwo (40.04s)
=== RUN   TestCreateVolumeFromSnapshot
=== RUN   TestCreateVolumeFromSnapshot/Not_supported
--- PASS: TestCreateVolumeFromSnapshot (0.00s)
    --- PASS: TestCreateVolumeFromSnapshot/Not_supported (0.00s)
=== RUN   TestCreateVolume
=== RUN   TestCreateVolume/Volume_capacity_is_nil
=== RUN   TestCreateVolume/Volume_capacity_is_zero
=== RUN   TestCreateVolume/Volume_with_general-purpose_profile_and_invalid_iops
=== RUN   TestCreateVolume/Volume_with_no_validation_issues
=== RUN   TestCreateVolume/Volume_creation_failure
=== RUN   TestCreateVolume/Volume_creation_with_encryption
=== RUN   TestCreateVolume/Volume_creation_with_resource_group_ID_and_Name_empty
=== RUN   TestCreateVolume/Volume_with_test-purpose_profile_and_invalid_iops
=== RUN   TestCreateVolume/Volume_creation_failure#01
=== RUN   TestCreateVolume/Volume_name_is_nil
=== RUN   TestCreateVolume/Volume_name_is_empty
=== RUN   TestCreateVolume/Volume_in_pending_state
--- PASS: TestCreateVolume (120.12s)
    --- PASS: TestCreateVolume/Volume_capacity_is_nil (0.00s)
    --- PASS: TestCreateVolume/Volume_capacity_is_zero (0.00s)
    --- PASS: TestCreateVolume/Volume_with_general-purpose_profile_and_invalid_iops (0.00s)
    --- PASS: TestCreateVolume/Volume_with_no_validation_issues (0.00s)
    --- PASS: TestCreateVolume/Volume_creation_failure (40.04s)
    --- PASS: TestCreateVolume/Volume_creation_with_encryption (0.00s)
    --- PASS: TestCreateVolume/Volume_creation_with_resource_group_ID_and_Name_empty (0.00s)
    --- PASS: TestCreateVolume/Volume_with_test-purpose_profile_and_invalid_iops (0.00s)
    --- PASS: TestCreateVolume/Volume_creation_failure#01 (40.04s)
    --- PASS: TestCreateVolume/Volume_name_is_nil (0.00s)
    --- PASS: TestCreateVolume/Volume_name_is_empty (0.00s)
    --- PASS: TestCreateVolume/Volume_in_pending_state (40.03s)
=== RUN   TestDeleteSnapshot
=== RUN   TestDeleteSnapshot/Not_supported_yet
=== RUN   TestDeleteSnapshot/Not_a_valid_snapshot
--- PASS: TestDeleteSnapshot (40.04s)
    --- PASS: TestDeleteSnapshot/Not_supported_yet (0.00s)
    --- PASS: TestDeleteSnapshot/Not_a_valid_snapshot (40.04s)
=== RUN   TestDeleteVolume
=== RUN   TestDeleteVolume/Not_supported_yet
=== RUN   TestDeleteVolume/False_positive:_No_volume_being_sent
=== RUN   TestDeleteVolume/Incorrect_volume_ID
=== RUN   TestDeleteVolume/Incorrect_volume_ID#01
--- PASS: TestDeleteVolume (80.04s)
    --- PASS: TestDeleteVolume/Not_supported_yet (40.02s)
    --- PASS: TestDeleteVolume/False_positive:_No_volume_being_sent (0.00s)
    --- PASS: TestDeleteVolume/Incorrect_volume_ID (0.00s)
    --- PASS: TestDeleteVolume/Incorrect_volume_ID#01 (40.01s)
=== RUN   TestDeleteVolumeTwo
--- PASS: TestDeleteVolumeTwo (120.03s)
=== RUN   Test_Errors
=== RUN   Test_Errors/Case_ErrorUnclassified
=== RUN   Test_Errors/Case_DefaultCode
=== RUN   Test_Errors/Case_ErrorUnknownProvider
=== RUN   Test_Errors/Case_Wrapped
=== RUN   Test_Errors/Case_MultiWrapped
=== RUN   Test_Errors/Case_Properties
--- PASS: Test_Errors (0.00s)
    --- PASS: Test_Errors/Case_ErrorUnclassified (0.00s)
    --- PASS: Test_Errors/Case_DefaultCode (0.00s)
    --- PASS: Test_Errors/Case_ErrorUnknownProvider (0.00s)
    --- PASS: Test_Errors/Case_Wrapped (0.00s)
    --- PASS: Test_Errors/Case_MultiWrapped (0.00s)
    --- PASS: Test_Errors/Case_Properties (0.00s)
=== RUN   TestExpandVolume
=== RUN   TestExpandVolume/OK
=== RUN   TestExpandVolume/same_size-success
=== RUN   TestExpandVolume/volume_not_found
--- PASS: TestExpandVolume (40.04s)
    --- PASS: TestExpandVolume/OK (0.00s)
    --- PASS: TestExpandVolume/same_size-success (0.00s)
    --- PASS: TestExpandVolume/volume_not_found (40.04s)
=== RUN   TestGetSnapshotWithVolumeID
=== RUN   TestGetSnapshotWithVolumeID/Not_supported_yet
=== RUN   TestGetSnapshotWithVolumeID/Wrong_volume_ID
--- PASS: TestGetSnapshotWithVolumeID (40.04s)
    --- PASS: TestGetSnapshotWithVolumeID/Not_supported_yet (0.00s)
    --- PASS: TestGetSnapshotWithVolumeID/Wrong_volume_ID (40.04s)
=== RUN   TestGetSnapshot
=== RUN   TestGetSnapshot/Not_supported_yet
--- PASS: TestGetSnapshot (0.00s)
    --- PASS: TestGetSnapshot/Not_supported_yet (0.00s)
=== RUN   TestGetVolumeAttachment
=== RUN   TestGetVolumeAttachment/Instance_ID_is_nil
=== RUN   TestGetVolumeAttachment/Volume_ID_is_nil
--- PASS: TestGetVolumeAttachment (0.00s)
    --- PASS: TestGetVolumeAttachment/Instance_ID_is_nil (0.00s)
    --- PASS: TestGetVolumeAttachment/Volume_ID_is_nil (0.00s)
=== RUN   TestGetVolume
=== RUN   TestGetVolume/OK
=== RUN   TestGetVolume/Wrong_volume_ID
=== RUN   TestGetVolume/Volume_without_zone
--- PASS: TestGetVolume (40.04s)
    --- PASS: TestGetVolume/OK (0.00s)
    --- PASS: TestGetVolume/Wrong_volume_ID (0.00s)
    --- PASS: TestGetVolume/Volume_without_zone (40.04s)
=== RUN   TestGetVolumeByName
=== RUN   TestGetVolumeByName/OK
=== RUN   TestGetVolumeByName/Wrong_volume_ID
=== RUN   TestGetVolumeByName/Volume_without_zone
=== RUN   TestGetVolumeByName/Empty_volume_name
--- PASS: TestGetVolumeByName (80.08s)
    --- PASS: TestGetVolumeByName/OK (0.00s)
    --- PASS: TestGetVolumeByName/Wrong_volume_ID (40.04s)
    --- PASS: TestGetVolumeByName/Volume_without_zone (40.04s)
    --- PASS: TestGetVolumeByName/Empty_volume_name (0.00s)
=== RUN   TestGetVolumeByRequestID
=== RUN   TestGetVolumeByRequestID/Not_supported_yet
--- PASS: TestGetVolumeByRequestID (0.00s)
    --- PASS: TestGetVolumeByRequestID/Not_supported_yet (0.00s)
=== RUN   TestListAllSnapshots
=== RUN   TestListAllSnapshots/Not_supported_yet
--- PASS: TestListAllSnapshots (0.00s)
    --- PASS: TestListAllSnapshots/Not_supported_yet (0.00s)
=== RUN   TestListSnapshots
=== RUN   TestListSnapshots/Not_supported_yet
--- PASS: TestListSnapshots (0.00s)
    --- PASS: TestListSnapshots/Not_supported_yet (0.00s)
=== RUN   TestListVolumes
=== RUN   TestListVolumes/Filter_by_zone
=== RUN   TestListVolumes/Filter_by_zone,_1_entry_per_page
=== RUN   TestListVolumes/Filter_by_zone:_no_volume_found
=== RUN   TestListVolumes/Filter_by_name
=== RUN   TestListVolumes/Filter_by_name:_volume_not_found
=== RUN   TestListVolumes/Filter_by_resource_group_ID
=== RUN   TestListVolumes/Filter_by_resource_group_ID:_no_volume_found
=== RUN   TestListVolumes/List_all_volumes
=== RUN   TestListVolumes/Unexpected_format_of_'Next'_parameter_in_ListVolumes_response
=== RUN   TestListVolumes/Invalid_limit_value
=== RUN   TestListVolumes/Invalid_start_volume_ID
--- PASS: TestListVolumes (80.09s)
    --- PASS: TestListVolumes/Filter_by_zone (0.00s)
    --- PASS: TestListVolumes/Filter_by_zone,_1_entry_per_page (0.00s)
    --- PASS: TestListVolumes/Filter_by_zone:_no_volume_found (0.00s)
    --- PASS: TestListVolumes/Filter_by_name (0.00s)
    --- PASS: TestListVolumes/Filter_by_name:_volume_not_found (40.01s)
    --- PASS: TestListVolumes/Filter_by_resource_group_ID (0.00s)
    --- PASS: TestListVolumes/Filter_by_resource_group_ID:_no_volume_found (0.00s)
    --- PASS: TestListVolumes/List_all_volumes (0.00s)
    --- PASS: TestListVolumes/Unexpected_format_of_'Next'_parameter_in_ListVolumes_response (0.01s)
    --- PASS: TestListVolumes/Invalid_limit_value (0.02s)
    --- PASS: TestListVolumes/Invalid_start_volume_ID (40.04s)
=== RUN   TestOrderSnapshot
=== RUN   TestOrderSnapshot/Not_supported_yet
=== RUN   TestOrderSnapshot/Not_supported_yet#01
--- PASS: TestOrderSnapshot (40.04s)
    --- PASS: TestOrderSnapshot/Not_supported_yet (0.00s)
    --- PASS: TestOrderSnapshot/Not_supported_yet#01 (40.04s)
=== RUN   TestOrderSnapshotTwo
--- PASS: TestOrderSnapshotTwo (40.03s)
=== RUN   TestNewProvider
--- PASS: TestNewProvider (0.00s)
=== RUN   TestGetTestProvider
--- PASS: TestGetTestProvider (0.00s)
=== RUN   TestOpenSession
--- PASS: TestOpenSession (0.00s)
=== RUN   TestGetTestOpenSession
--- PASS: TestGetTestOpenSession (0.00s)
=== RUN   TestGetPrivateEndpoint
--- PASS: TestGetPrivateEndpoint (0.00s)
=== RUN   TestTokenGenerator
--- PASS: TestTokenGenerator (0.03s)
=== RUN   TestSetRetryParameters
--- PASS: TestSetRetryParameters (0.00s)
=== RUN   TestRetry
{"level":"info","ts":"2022-02-04T06:11:02.441-0800","caller":"provider/util_test.go:59","msg":"Testing retry with successful attempt"}
{"level":"info","ts":"2022-02-04T06:11:02.441-0800","caller":"provider/util_test.go:76","msg":"Testing retry with unsuccessful attempt"}
{"level":"info","ts":"2022-02-04T06:11:02.441-0800","caller":"provider/util.go:86","msg":"Error while executing the function. Re-attempting execution ..","attempt..":2,"retry-gap":10,"max-retry-Attempts":2,"error":"Trace Code:,  Please check "}
{"level":"info","ts":"2022-02-04T06:11:12.441-0800","caller":"provider/util_test.go:76","msg":"Testing retry with unsuccessful attempt"}
--- PASS: TestRetry (10.00s)
=== RUN   TestSkipRetry
--- PASS: TestSkipRetry (0.00s)
=== RUN   TestRetryWithError
{"level":"info","ts":"2022-02-04T06:11:12.442-0800","caller":"provider/util_test.go:123","msg":"Testing retry with error"}
{"level":"info","ts":"2022-02-04T06:11:17.447-0800","caller":"provider/util_test.go:123","msg":"Testing retry with error"}
--- PASS: TestRetryWithError (5.00s)
=== RUN   TestFromProviderToLibVolume
--- PASS: TestFromProviderToLibVolume (0.00s)
=== RUN   TestToInt
--- PASS: TestToInt (0.00s)
=== RUN   TestToInt64
--- PASS: TestToInt64 (0.00s)
=== RUN   TestIsValidVolumeIDFormat
--- PASS: TestIsValidVolumeIDFormat (0.00s)
=== RUN   TestWaitForValidVolumeState
=== RUN   TestWaitForValidVolumeState/OK
=== RUN   TestWaitForValidVolumeState/Invalid_volume_state
=== RUN   TestWaitForValidVolumeState/Volume_without_zone
--- PASS: TestWaitForValidVolumeState (40.04s)
    --- PASS: TestWaitForValidVolumeState/OK (0.00s)
    --- PASS: TestWaitForValidVolumeState/Invalid_volume_state (20.02s)
    --- PASS: TestWaitForValidVolumeState/Volume_without_zone (20.02s)
PASS
coverage: 71.1% of statements
ok  	github.com/IBM/ibmcloud-storage-volume-lib/volume-providers/vpc/provider	895.987s	coverage: 71.1% of statements

```